### PR TITLE
s3 prefix defaults to project slug

### DIFF
--- a/packages/cli-common/resources/templates/template-workspace/docker-compose.yaml
+++ b/packages/cli-common/resources/templates/template-workspace/docker-compose.yaml
@@ -13,11 +13,6 @@ services:
       CONTEMBER_ROOT_TOKEN: '0000000000000000000000000000000000000000' # openssl rand -hex 20
       CONTEMBER_LOGIN_TOKEN: '1111111111111111111111111111111111111111' # openssl rand -hex 20
 
-      CONTEMBER_CONFIG_YAML: |
-        projectDefaults:
-          s3:
-            prefix: '%project.slug%'
-
       DEFAULT_DB_HOST: 'postgres'
       DEFAULT_DB_PORT: '5432'
       DEFAULT_DB_USER: 'contember'

--- a/packages/engine-s3-plugin/src/S3ConfigProcessor.ts
+++ b/packages/engine-s3-plugin/src/S3ConfigProcessor.ts
@@ -5,7 +5,6 @@ import { Typesafe } from '@contember/engine-common'
 export class S3ConfigProcessor implements ConfigProcessor<ProjectWithS3Config> {
 	getDefaultEnv(): Record<string, string> {
 		return {
-			DEFAULT_S3_PREFIX: '',
 			DEFAULT_S3_ENDPOINT: '',
 			DEFAULT_S3_REGION: 'us-east-1',
 			DEFAULT_S3_PROVIDER: 'aws',
@@ -18,8 +17,8 @@ export class S3ConfigProcessor implements ConfigProcessor<ProjectWithS3Config> {
 			projectDefaults: {
 				...template.projectDefaults,
 				s3: {
-					bucket: `%?project.env.S3_BUCKET||project.slug%`,
-					prefix: `%project.env.S3_PREFIX%`,
+					bucket: `%project.env.S3_BUCKET%`,
+					prefix: `%?project.env.S3_PREFIX||project.slug%`,
 					region: `%project.env.S3_REGION%`,
 					endpoint: `%project.env.S3_ENDPOINT%`,
 					provider: '%project.env.S3_PROVIDER%',


### PR DESCRIPTION
I have no idea if this will actually work. Untested.

Defaulting S3_BUCKET to project slug seems completely useless. You usually cannot have dynamic s3 buckets.