### PR TITLE
Allow custom primary for admin

### DIFF
--- a/packages/schema-utils/src/schemaNormalizer.ts
+++ b/packages/schema-utils/src/schemaNormalizer.ts
@@ -11,7 +11,7 @@ export const normalizeSchema = <S extends Schema>(schema: S): S => {
 				[ProjectRole.ADMIN]: {
 					stages: '*',
 					variables: {},
-					entities: new AllowAllPermissionFactory().create(schema.model),
+					entities: new AllowAllPermissionFactory().create(schema.model, true),
 					s3: {
 						'**': {
 							upload: true,
@@ -23,7 +23,7 @@ export const normalizeSchema = <S extends Schema>(schema: S): S => {
 				[ProjectRole.CONTENT_ADMIN]: {
 					stages: '*',
 					variables: {},
-					entities: new AllowAllPermissionFactory().create(schema.model),
+					entities: new AllowAllPermissionFactory().create(schema.model, true),
 					s3: {
 						'**': {
 							upload: true,


### PR DESCRIPTION
If I use decorators and don't explicitly declare the `admin` role, `@acl.allowCustomPrimary()` has no effect. 

This PR allows custom primary for admin always since there is no security risk involved (because it already knows about all existing ids).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/287)
<!-- Reviewable:end -->
