### PR TITLE
chore(actions): update to Node16

### DIFF
--- a/.github/actions/extract-version/action.yaml
+++ b/.github/actions/extract-version/action.yaml
@@ -10,5 +10,5 @@ outputs:
   versions:
     description: 'String of possible tags separated by space'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,9 +22,9 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'yarn'

--- a/.github/workflows/publish-canary.yaml
+++ b/.github/workflows/publish-canary.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         image: [cli, engine-alpine, engine-debian, engine-ee-alpine, engine-ee-debian]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -18,7 +18,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'yarn'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,10 +7,10 @@ jobs:
   publish-node:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'yarn'
@@ -48,7 +48,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'yarn'


### PR DESCRIPTION
The GitHub Actions workflow gives the following annotation while running the action:

> Node.js 12 actions are deprecated. For more information see: github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12.

You can see more here: https://github.com/actions/setup-node/compare/v2.5.1...v3.0.0

Signed-off-by: Enes <ahmedenesturan@gmail.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/345)
<!-- Reviewable:end -->
