### PR TITLE
fix: engine start command migration does not need dot from v1.2

### DIFF
--- a/packages/cli-common/resources/templates/template-workspace/package.json
+++ b/packages/cli-common/resources/templates/template-workspace/package.json
@@ -2,7 +2,7 @@
   "scripts-template": {
     "contember": "docker-compose run contember-cli",
     "start": "npm run start-engine && npm run start-admin",
-    "start-engine": "docker-compose up --detach && npm run contember migrations:execute . --yes",
+    "start-engine": "docker-compose up --detach && npm run contember migrations:execute --yes",
     "start-admin": "vite admin --port 1480 --host 0.0.0.0",
     "build": "npm run build-admin && npm run build-api",
     "build-admin": "tsc --project admin && vite build admin",


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/371)
<!-- Reviewable:end -->
