### PR TITLE
improve schema definition API

### DIFF
--- a/packages/schema-definition/src/index.ts
+++ b/packages/schema-definition/src/index.ts
@@ -1,7 +1,81 @@
+import * as AclDefinition from './acl/definition'
+import * as ActionsDefinition from './actions/definition'
+import * as InputValidation from './validation'
+import { SchemaDefinition } from './model'
+import { createSchema } from './createSchema'
+
 export { AllowAllPermissionFactory } from '@contember/schema-utils'
 export { PermissionsBuilder } from './acl/builder/PermissionsBuilder'
-export * as InputValidation from './validation'
-export * as AclDefinition from './acl/definition'
-export * as ActionsDefinition from './actions/definition'
-export * from './createSchema'
 export * from './model'
+
+export { AclDefinition, ActionsDefinition, SchemaDefinition, InputValidation, createSchema }
+
+export const c = {
+
+	// ACL
+	// ACL entity decorators
+	AllowCustomPrimary: AclDefinition.allowCustomPrimary,
+	Allow: AclDefinition.allow,
+	// ACL factories
+	createRole: AclDefinition.createRole,
+	createConditionVariable: AclDefinition.createConditionVariable,
+	createEntityVariable: AclDefinition.createEntityVariable,
+	createPredefinedVariable: AclDefinition.createPredefinedVariable,
+	// ACL utilities
+	canCreate: AclDefinition.canCreate,
+	canRead: AclDefinition.canRead,
+	canUpdate: AclDefinition.canUpdate,
+	canDelete: AclDefinition.canDelete,
+
+
+	// Actions
+	// Actions entity decorators
+	Watch: ActionsDefinition.watch,
+	Trigger: ActionsDefinition.trigger,
+	// Actions factories
+	createActionsTarget: ActionsDefinition.createTarget,
+
+
+	// Model
+	// Model entity decorators
+	ExtendEntity: SchemaDefinition.extendEntity,
+	Index: SchemaDefinition.Index,
+	Unique: SchemaDefinition.Unique,
+	View: SchemaDefinition.View,
+	DisableEventLog: SchemaDefinition.DisableEventLog,
+	OrderBy: SchemaDefinition.OrderBy,
+	// Model field factories
+	column: SchemaDefinition.column,
+	boolColumn: SchemaDefinition.boolColumn,
+	intColumn: SchemaDefinition.intColumn,
+	doubleColumn: SchemaDefinition.doubleColumn,
+	dateColumn: SchemaDefinition.dateColumn,
+	dateTimeColumn: SchemaDefinition.dateTimeColumn,
+	jsonColumn: SchemaDefinition.jsonColumn,
+	stringColumn: SchemaDefinition.stringColumn,
+	enumColumn: SchemaDefinition.enumColumn,
+	uuidColumn: SchemaDefinition.uuidColumn,
+	manyHasMany: SchemaDefinition.manyHasMany,
+	manyHasManyInverse: SchemaDefinition.manyHasManyInverse,
+	manyHasOne: SchemaDefinition.manyHasOne,
+	oneHasOne: SchemaDefinition.oneHasOne,
+	oneHasOneInverse: SchemaDefinition.oneHasOneInverse,
+	oneHasMany: SchemaDefinition.oneHasMany,
+	// Model factories
+	createEnum: SchemaDefinition.createEnum,
+
+
+	// Validation
+	// Validation field decorators
+	Assert: InputValidation.assert,
+	Required: InputValidation.required,
+	AssertDefined: InputValidation.assertDefined,
+	AssertNotEmpty: InputValidation.assertNotEmpty,
+	AssertPattern: InputValidation.assertPattern,
+	AssertMinLength: InputValidation.assertMinLength,
+	AssertMaxLength: InputValidation.assertMaxLength,
+	ValidateWhen: InputValidation.when,
+	// Validation utilities
+	rules: InputValidation.rules,
+
+}

--- a/packages/schema-definition/src/model/definition/OrderByDefinition.ts
+++ b/packages/schema-definition/src/model/definition/OrderByDefinition.ts
@@ -3,17 +3,17 @@ import { extendEntity } from './extensions'
 import { DecoratorFunction } from '../../utils'
 
 
-export type OrderByOptions = { path: string[]; direction?: Model.OrderDirection }
+export type OrderByOptions = { path: string[]; direction?: Model.OrderDirection | `${Model.OrderDirection}` }
+
 
 export function OrderBy<T>(options: OrderByOptions): DecoratorFunction<T>
-export function OrderBy<T>(path: (keyof T), direction?: Model.OrderDirection): DecoratorFunction<T>
-export function OrderBy<T>(options: OrderByOptions | keyof T, direction?: Model.OrderDirection): DecoratorFunction<T> {
+export function OrderBy<T>(path: (keyof T), direction?: Model.OrderDirection | `${Model.OrderDirection}`): DecoratorFunction<T>
+export function OrderBy<T>(options: OrderByOptions | keyof T, direction?: `${Model.OrderDirection}`): DecoratorFunction<T> {
 	return extendEntity(({ entity }) => {
 		const path = (typeof options !== 'object' ? [options] : options.path) as string[]
-		const dir =
-			((typeof options === 'object' && options.direction)
-				? options.direction
-				: direction) ?? Model.OrderDirection.asc
+		const dir = (((typeof options === 'object' && options.direction)
+			? options.direction
+			: direction) ?? Model.OrderDirection.asc) as Model.OrderDirection
 
 
 		return {

--- a/packages/schema-definition/src/model/definition/fieldDefinitions/ManyHasManyDefinition.ts
+++ b/packages/schema-definition/src/model/definition/fieldDefinitions/ManyHasManyDefinition.ts
@@ -15,10 +15,10 @@ export class ManyHasManyDefinitionImpl extends FieldDefinition<ManyHasManyDefini
 
 	orderBy(
 		field: string | string[],
-		direction: Model.OrderDirection = Model.OrderDirection.asc,
+		direction: Model.OrderDirection | `${Model.OrderDirection}` = Model.OrderDirection.asc,
 	): Interface<ManyHasManyDefinition> {
 		const path = typeof field === 'string' ? [field] : field
-		return this.withOption('orderBy', [...(this.options.orderBy || []), { path, direction }])
+		return this.withOption('orderBy', [...(this.options.orderBy || []), { path, direction: direction as Model.OrderDirection }])
 	}
 
 	createField({ name, conventions, entityName, entityRegistry }: CreateFieldContext): Model.AnyField {

--- a/packages/schema-definition/src/model/definition/fieldDefinitions/ManyHasManyInverseDefinition.ts
+++ b/packages/schema-definition/src/model/definition/fieldDefinitions/ManyHasManyInverseDefinition.ts
@@ -7,10 +7,10 @@ export class ManyHasManyInverseDefinitionImpl extends FieldDefinition<ManyHasMan
 
 	orderBy(
 		field: string | string[],
-		direction: Model.OrderDirection = Model.OrderDirection.asc,
+		direction: Model.OrderDirection | `${Model.OrderDirection}` = Model.OrderDirection.asc,
 	): Interface<ManyHasManyInverseDefinition> {
 		const path = typeof field === 'string' ? [field] : field
-		return this.withOption('orderBy', [...(this.options.orderBy || []), { path, direction }])
+		return this.withOption('orderBy', [...(this.options.orderBy || []), { path, direction: direction as Model.OrderDirection }])
 	}
 
 	createField({ name, conventions, entityName, entityRegistry }: CreateFieldContext): Model.AnyField {

--- a/packages/schema-definition/src/model/definition/fieldDefinitions/ManyHasOneDefinition.ts
+++ b/packages/schema-definition/src/model/definition/fieldDefinitions/ManyHasOneDefinition.ts
@@ -14,8 +14,8 @@ export class ManyHasOneDefinitionImpl extends FieldDefinition<ManyHasOneDefiniti
 		return this.withOption('joiningColumn', { ...this.options.joiningColumn, columnName })
 	}
 
-	onDelete(onDelete: Model.OnDelete): Interface<ManyHasOneDefinition> {
-		return this.withOption('joiningColumn', { ...this.options.joiningColumn, onDelete })
+	onDelete(onDelete: Model.OnDelete | `${Model.OnDelete}`): Interface<ManyHasOneDefinition> {
+		return this.withOption('joiningColumn', { ...this.options.joiningColumn, onDelete: onDelete as Model.OnDelete })
 	}
 
 	cascadeOnDelete(): Interface<ManyHasOneDefinition> {

--- a/packages/schema-definition/src/model/definition/fieldDefinitions/OneHasManyDefinition.ts
+++ b/packages/schema-definition/src/model/definition/fieldDefinitions/OneHasManyDefinition.ts
@@ -7,10 +7,10 @@ export class OneHasManyDefinitionImpl extends FieldDefinition<OneHasManyDefiniti
 
 	orderBy(
 		field: string | string[],
-		direction: Model.OrderDirection = Model.OrderDirection.asc,
+		direction: Model.OrderDirection | `${Model.OrderDirection}` = Model.OrderDirection.asc,
 	): Interface<OneHasManyDefinition> {
 		const path = typeof field === 'string' ? [field] : field
-		return this.withOption('orderBy', [...(this.options.orderBy || []), { path, direction }])
+		return this.withOption('orderBy', [...(this.options.orderBy || []), { path, direction: direction as Model.OrderDirection }])
 	}
 	createField({ name, entityRegistry }: CreateFieldContext): Model.AnyField {
 		const options = this.options

--- a/packages/schema-definition/src/model/definition/fieldDefinitions/OneHasOneDefinition.ts
+++ b/packages/schema-definition/src/model/definition/fieldDefinitions/OneHasOneDefinition.ts
@@ -13,8 +13,8 @@ export class OneHasOneDefinitionImpl extends FieldDefinition<OneHasOneDefinition
 		return this.withOption('joiningColumn', { ...this.joiningColumn, columnName })
 	}
 
-	onDelete(onDelete: Model.OnDelete): Interface<OneHasOneDefinition> {
-		return this.withOption('joiningColumn', { ...this.joiningColumn, onDelete })
+	onDelete(onDelete: Model.OnDelete | `${Model.OnDelete}`): Interface<OneHasOneDefinition> {
+		return this.withOption('joiningColumn', { ...this.joiningColumn, onDelete: onDelete as Model.OnDelete })
 	}
 
 	cascadeOnDelete(): Interface<OneHasOneDefinition> {

--- a/packages/schema-definition/src/validation/index.ts
+++ b/packages/schema-definition/src/validation/index.ts
@@ -52,7 +52,7 @@ export function fluent() {
 	return new RuleBranch([], [])
 }
 
-class RuleBranch {
+export class RuleBranch {
 	constructor(private conditions: Validation.Validator[], private branchRules: Validation.ValidationRule[]) {}
 
 	public buildRules = (): Validation.ValidationRule[] => {

--- a/packages/schema-definition/tests/cases/unit/extendEntity.test.ts
+++ b/packages/schema-definition/tests/cases/unit/extendEntity.test.ts
@@ -1,12 +1,12 @@
 import { Model } from '@contember/schema'
 import { assert, test } from 'vitest'
-import { createSchema, SchemaDefinition as def } from '../../../src'
+import { createSchema, c } from '../../../src'
 import { extendEntity, FieldDefinition } from '../../../src/model/definition'
 import { DecoratorFunction } from '../../../src/utils'
 
 namespace ExtendedModel {
 	export class Article {
-		title = def.stringColumn()
+		title = c.stringColumn()
 	}
 
 	const addField = (name: string, field: FieldDefinition<any>): DecoratorFunction<any> => {
@@ -25,7 +25,7 @@ namespace ExtendedModel {
 		}))
 	}
 
-	addField('lead', def.stringColumn())(Article)
+	addField('lead', c.stringColumn())(Article)
 }
 
 

--- a/packages/schema-definition/tests/cases/unit/readAclDefinitions.test.ts
+++ b/packages/schema-definition/tests/cases/unit/readAclDefinitions.test.ts
@@ -1,12 +1,12 @@
 import { expect, test } from 'vitest'
-import { createSchema, SchemaDefinition as def, AclDefinition as acl } from '../../../src'
+import { c, createSchema } from '../../../src'
 
 namespace SimpleModel {
-	export const publicRole = acl.createRole('public')
+	export const publicRole = c.createRole('public')
 
-	@acl.allow(publicRole, { read: true })
+	@c.Allow(publicRole, { read: true })
 	export class Book {
-		title = def.stringColumn()
+		title = c.stringColumn()
 	}
 }
 
@@ -26,7 +26,7 @@ test('simple definitions', () => {
 
 
 namespace RoleOptions {
-	export const publicRole = acl.createRole('public', {
+	export const publicRole = c.createRole('public', {
 		debug: true,
 		s3: {
 			foo: 'bar',
@@ -51,15 +51,15 @@ test('role options', () => {
 
 
 namespace ModelWithPredicate {
-	export const publicRole = acl.createRole('public')
+	export const publicRole = c.createRole('public')
 
-	@acl.allow(publicRole, {
+	@c.Allow(publicRole, {
 		when: { isPublished: { eq: true } },
 		read: true,
 	})
 	export class Book {
-		title = def.stringColumn()
-		isPublished = def.boolColumn()
+		title = c.stringColumn()
+		isPublished = c.boolColumn()
 	}
 }
 
@@ -85,15 +85,15 @@ test('definition with a predicate', () => {
 })
 
 namespace ModelWithPredicateOnField {
-	export const publicRole = acl.createRole('public')
+	export const publicRole = c.createRole('public')
 
-	@acl.allow(publicRole, {
+	@c.Allow(publicRole, {
 		when: { isPublished: { eq: true } },
 		read: ['title'],
 	})
 	export class Book {
-		title = def.stringColumn()
-		isPublished = def.boolColumn()
+		title = c.stringColumn()
+		isPublished = c.boolColumn()
 	}
 }
 
@@ -119,17 +119,17 @@ test('definition with a predicate on field', () => {
 
 
 namespace ModelWithModificationAcl {
-	export const publicRole = acl.createRole('public')
+	export const publicRole = c.createRole('public')
 
-	@acl.allow(publicRole, {
+	@c.Allow(publicRole, {
 		when: { isPublished: { eq: true } },
 		create: true,
 		update: true,
 		delete: true,
 	})
 	export class Book {
-		title = def.stringColumn()
-		isPublished = def.boolColumn()
+		title = c.stringColumn()
+		isPublished = c.boolColumn()
 	}
 }
 
@@ -161,19 +161,19 @@ test('definition with update, create, delete predicates', () => {
 
 
 namespace ModelWithMultiplePredicates {
-	export const publicRole = acl.createRole('public')
+	export const publicRole = c.createRole('public')
 
-	@acl.allow(publicRole, {
+	@c.Allow(publicRole, {
 		when: { isPublished: { eq: true } },
 		read: ['title'],
 	})
-	@acl.allow(publicRole, {
+	@c.Allow(publicRole, {
 		when: { isPublished: { eq: false } },
 		read: ['title'],
 	})
 	export class Book {
-		title = def.stringColumn()
-		isPublished = def.boolColumn()
+		title = c.stringColumn()
+		isPublished = c.boolColumn()
 	}
 }
 
@@ -208,23 +208,23 @@ test('definition with multiple predicates on a single field', () => {
 
 
 namespace ModelWithJoinedPredicateCollision {
-	export const publicRole = acl.createRole('public')
+	export const publicRole = c.createRole('public')
 
-	@acl.allow(publicRole, {
+	@c.Allow(publicRole, {
 		when: { isPublishedLoremIpsumDolorSitAmet: { eq: true } },
 		read: ['title'],
 	})
-	@acl.allow(publicRole, {
+	@c.Allow(publicRole, {
 		when: { isPublishedLoremIpsumDolorSitAmet: { eq: false } },
 		read: ['title', 'isPublishedLoremIpsumDolorSitAmet'],
 	})
-	@acl.allow(publicRole, {
+	@c.Allow(publicRole, {
 		when: { isPublishedLoremIpsumDolorSitAmet: { eq: false } },
 		read: ['isPublishedLoremIpsumDolorSitAmet'],
 	})
 	export class Book {
-		title = def.stringColumn()
-		isPublishedLoremIpsumDolorSitAmet = def.boolColumn()
+		title = c.stringColumn()
+		isPublishedLoremIpsumDolorSitAmet = c.boolColumn()
 	}
 }
 
@@ -274,15 +274,15 @@ test('definition with collision', () => {
 
 
 namespace ModelWithMultipleRolesForSinglePredicate {
-	export const publicRole = acl.createRole('public')
-	export const adminRole = acl.createRole('admin')
+	export const publicRole = c.createRole('public')
+	export const adminRole = c.createRole('admin')
 
-	@acl.allow([publicRole, adminRole], {
+	@c.Allow([publicRole, adminRole], {
 		read: ['title'],
 	})
 	export class Book {
-		title = def.stringColumn()
-		isPublished = def.boolColumn()
+		title = c.stringColumn()
+		isPublished = c.boolColumn()
 	}
 }
 
@@ -323,23 +323,23 @@ test('definition with multiple roles in single predicate', () => {
 })
 
 namespace ModelWithAclPredicateReferences {
-	export const publicRole = acl.createRole('public')
+	export const publicRole = c.createRole('public')
 
-	@acl.allow(publicRole, {
+	@c.Allow(publicRole, {
 		when: { isPublished: { eq: true } },
 		read: ['title'],
 	})
 	export class Book {
-		title = def.stringColumn()
-		isPublished = def.boolColumn()
+		title = c.stringColumn()
+		isPublished = c.boolColumn()
 	}
-	@acl.allow(publicRole, {
-		when: { book: acl.canRead('title') },
+	@c.Allow(publicRole, {
+		when: { book: c.canRead('title') },
 		read: ['content'],
 	})
 	export class BookReview {
-		book = def.manyHasOne(Book)
-		content = def.stringColumn()
+		book = c.manyHasOne(Book)
+		content = c.stringColumn()
 	}
 }
 
@@ -383,15 +383,15 @@ test('definition with predicate references', () => {
 
 
 namespace ModelWithVariables {
-	export const managerRole = acl.createRole('manager')
-	export const bookIdVariable = acl.createEntityVariable('bookId', 'Book', managerRole)
+	export const managerRole = c.createRole('manager')
+	export const bookIdVariable = c.createEntityVariable('bookId', 'Book', managerRole)
 
-	@acl.allow(managerRole, {
+	@c.Allow(managerRole, {
 		when: { id: bookIdVariable },
 		read: ['title'],
 	})
 	export class Book {
-		title = def.stringColumn()
+		title = c.stringColumn()
 	}
 }
 
@@ -425,11 +425,11 @@ test('definition with variables', () => {
 })
 
 namespace ModelWithAllowCustomPrimary {
-	export const publicRole = acl.createRole('public')
+	export const publicRole = c.createRole('public')
 
-	@acl.allowCustomPrimary(publicRole)
+	@c.AllowCustomPrimary(publicRole)
 	export class Book {
-		title = def.stringColumn()
+		title = c.stringColumn()
 	}
 }
 
@@ -446,11 +446,11 @@ test('allow custom primary', () => {
 })
 
 namespace ModelWithAllowCustomPrimaryAllRoles {
-	export const publicRole = acl.createRole('public')
+	export const publicRole = c.createRole('public')
 
-	@acl.allowCustomPrimary()
+	@c.AllowCustomPrimary()
 	export class Book {
-		title = def.stringColumn()
+		title = c.stringColumn()
 	}
 }
 
@@ -468,24 +468,24 @@ test('allow custom primary', () => {
 
 
 namespace ModelWithInvalidAclPredicateReferences {
-	export const publicRole = acl.createRole('public')
+	export const publicRole = c.createRole('public')
 
-	@acl.allow(publicRole, {
+	@c.Allow(publicRole, {
 		when: { isPublished: { eq: true } },
 		read: ['title'],
 	})
 	export class Book {
-		title = def.stringColumn()
-		isPublished = def.boolColumn()
+		title = c.stringColumn()
+		isPublished = c.boolColumn()
 	}
 
-	@acl.allow(publicRole, {
-		when: { content: acl.canRead('title') },
+	@c.Allow(publicRole, {
+		when: { content: c.canRead('title') },
 		read: ['content'],
 	})
 	export class BookReview {
-		book = def.manyHasOne(Book)
-		content = def.stringColumn()
+		book = c.manyHasOne(Book)
+		content = c.stringColumn()
 	}
 }
 
@@ -498,16 +498,16 @@ test('definition with invalid predicate references', () => {
 
 
 namespace ModelWithPredefinedVariables {
-	export const customerRole = acl.createRole('customer')
-	export const personId = acl.createPredefinedVariable('person', 'personID', customerRole)
+	export const customerRole = c.createRole('customer')
+	export const personId = c.createPredefinedVariable('person', 'personID', customerRole)
 
-	@acl.allow(customerRole, {
+	@c.Allow(customerRole, {
 		when: { personId: personId },
 		read: true,
 	})
 	export class Order {
-		personId = def.uuidColumn().notNull()
-		valueCents = def.intColumn().notNull()
+		personId = c.uuidColumn().notNull()
+		valueCents = c.intColumn().notNull()
 	}
 }
 
@@ -542,11 +542,11 @@ test('definition with predefined variables', () => {
 })
 
 namespace InvalidModel {
-	export const publicRole = acl.createRole('public')
+	export const publicRole = c.createRole('public')
 
-	@acl.allow(publicRole, { read: ['bar'] as any })
+	@c.Allow(publicRole, { read: ['bar'] as any })
 	export class Book {
-		title = def.stringColumn()
+		title = c.stringColumn()
 	}
 }
 

--- a/packages/schema-definition/tests/cases/unit/readActions.test.ts
+++ b/packages/schema-definition/tests/cases/unit/readActions.test.ts
@@ -1,11 +1,10 @@
-import { SchemaDefinition as def, ActionsDefinition as actions } from '../../../src'
-import { Model } from '@contember/schema'
+import { c } from '../../../src'
 import { expect, test } from 'vitest'
 import { createActions } from '../../../src/actions/definition'
 
 namespace SimpleActions {
 
-	@actions.watch({
+	@c.Watch({
 		name: 'book_watch',
 		watch: `
 			title
@@ -16,36 +15,36 @@ namespace SimpleActions {
 		webhook: '%webhookUrl%/book/updated',
 	})
 	export class Book {
-		title = def.stringColumn()
-		tags = def.manyHasMany(Tag)
-		category = def.manyHasOne(Category)
+		title = c.stringColumn()
+		tags = c.manyHasMany(Tag)
+		category = c.manyHasOne(Category)
 	}
 
 	export class Tag {
-		locales = def.oneHasMany(TagLocale, 'tag')
+		locales = c.oneHasMany(TagLocale, 'tag')
 	}
 
-	@def.Unique('tag', 'locale')
+	@c.Unique('tag', 'locale')
 	export class TagLocale {
-		tag = def.manyHasOne(Tag, 'locales')
-		name = def.stringColumn()
-		locale = def.manyHasOne(Locale)
+		tag = c.manyHasOne(Tag, 'locales')
+		name = c.stringColumn()
+		locale = c.manyHasOne(Locale)
 	}
 
 
 	export class Category {
-		locales = def.oneHasMany(CategoryLocale, 'category')
+		locales = c.oneHasMany(CategoryLocale, 'category')
 	}
 
-	@def.Unique('category', 'locale')
+	@c.Unique('category', 'locale')
 	export class CategoryLocale {
-		category = def.manyHasOne(Category, 'locales')
-		name = def.stringColumn()
-		locale = def.manyHasOne(Locale)
+		category = c.manyHasOne(Category, 'locales')
+		name = c.stringColumn()
+		locale = c.manyHasOne(Locale)
 	}
 
 	export class Locale {
-		code = def.stringColumn().notNull().unique()
+		code = c.stringColumn().notNull().unique()
 	}
 }
 


### PR DESCRIPTION
This PR aims to enhance the schema definition API by few things:
- consolidate several schema definition APIs (like SchemaDefinition, AclDefinition etc.) into a single object called "c". 
- allow to pass enums as literal
- all decorators in this new API starts with a first letter upper case

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/430)
<!-- Reviewable:end -->
