### PR TITLE
WIP: migrations: fill/copy value improvements

### DIFF
--- a/packages/schema-migrations/src/modifications/columns/CreateColumnModification.ts
+++ b/packages/schema-migrations/src/modifications/columns/CreateColumnModification.ts
@@ -1,5 +1,5 @@
 import { escapeValue, MigrationBuilder } from '@contember/database-migrations'
-import { Model, Schema } from '@contember/schema'
+import { JSONValue, Model, Schema } from '@contember/schema'
 import { addField, SchemaUpdater, updateEntity, updateModel } from '../utils/schemaUpdateUtils'
 import { createModificationType, Differ, ModificationHandler } from '../ModificationHandler'
 import { wrapIdentifier } from '../../utils/dbHelpers'
@@ -72,7 +72,7 @@ export class CreateColumnModificationHandler implements ModificationHandler<Crea
 export interface CreateColumnModificationData {
 	entityName: string
 	field: Model.AnyColumn
-	fillValue?: any
+	fillValue?: JSONValue
 	copyValue?: string
 }
 

--- a/packages/schema-migrations/src/modifications/columns/helpers.ts
+++ b/packages/schema-migrations/src/modifications/columns/helpers.ts
@@ -1,0 +1,20 @@
+import { wrapIdentifier } from '../../utils/dbHelpers'
+import { escapeValue } from '@contember/database-migrations'
+import { getColumnName } from '@contember/schema-utils'
+import { JSONValue, Model } from '@contember/schema'
+
+export const formatSeedExpression = ({ model, entity, columnType, fillValue, copyValue }: {
+	model: Model.Schema
+	entity: Model.Entity
+	columnType: string
+	fillValue?: JSONValue
+	copyValue?: string
+}): string | null => {
+	if (fillValue !== undefined) {
+		return escapeValue(fillValue)
+	} else if (copyValue !== undefined) {
+		const copyFrom = getColumnName(model, entity, copyValue)
+		return `${wrapIdentifier(copyFrom)}::${columnType}`
+	}
+	return null
+}

--- a/packages/schema-migrations/tests/cases/integration/createColumn.test.ts
+++ b/packages/schema-migrations/tests/cases/integration/createColumn.test.ts
@@ -30,9 +30,9 @@ testMigrations('create a column with default value', {
 			fillValue: 'unnamed author',
 		},
 	],
-	sql: SQL`ALTER TABLE "author" ADD "name" text;
-UPDATE "author" SET "name" = $pga$unnamed author$pga$;
-SET CONSTRAINTS ALL IMMEDIATE; SET CONSTRAINTS ALL DEFERRED;
+	sql: SQL`ALTER TABLE "author" ADD "name" text; 
+ALTER TABLE "author" ALTER "name" SET DATA TYPE text USING $pga$unnamed author$pga$; 
+SET CONSTRAINTS ALL IMMEDIATE; SET CONSTRAINTS ALL DEFERRED; 
 ALTER TABLE "author" ALTER "name" SET NOT NULL;`,
 })
 
@@ -64,7 +64,7 @@ testMigrations('create a column with copy value', {
 	],
 	noDiff: true,
 	sql: SQL`ALTER TABLE "author" ADD "name" text;
-UPDATE "author" SET "name" = "email"::text;
+ALTER TABLE "author" ALTER "name" SET DATA TYPE text USING "email"::text;
 SET CONSTRAINTS ALL IMMEDIATE; SET CONSTRAINTS ALL DEFERRED;
 ALTER TABLE "author" ALTER "name" SET NOT NULL;`,
 })


### PR DESCRIPTION
- allow to use copyValue/fillValue in updateColumnDefinition, so you can fill a value when changing a field to not-null
- copyValue/fillValue is done using "using" expression, so it does not affect event log. TODO: discuss this point

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/444)
<!-- Reviewable:end -->
