### PR TITLE
CLI: migrations:execute - add "until" option

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,6 +21,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+
   cli-sandbox:
     image: node:18
     working_dir: /src/sandbox
@@ -34,9 +35,15 @@ services:
       CONTEMBER_API_TOKEN: '0000000000000000000000000000000000000000'
       CONTEMBER_INSTANCE: 'http://api:4000'
       CONTEMBER_PROJECT_NAME: 'sandbox'
+      CONTEMBER_CLI_PACKAGE_ROOT: '/src/packages/cli'
     entrypoint:
-      - node
-      - /src/packages/cli/dist/src/run.js
+      - yarn
+      - run
+      - "-T"
+      - tsx
+      - "--conditions=typescript"
+      - /src/packages/cli/src/run.ts
+
   api:
     image: node:18
     working_dir: /src

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test-e2e": "yarn workspaces foreach run test-e2e",
     "eslint:lint": "eslint \"**/*.{ts,tsx}\" ",
     "eslint:fix": "eslint --fix \"**/*.{ts,tsx}\" ",
-    "tag-version": "./scripts/npm/tag-version.sh $@"
+    "tag-version": "./scripts/npm/tag-version.sh $@",
+    "contember": "docker-compose run --rm cli-sandbox"
   },
   "husky": {
     "hooks": {

--- a/packages/cli/src/commands/migrations/MigrationExecuteCommand.ts
+++ b/packages/cli/src/commands/migrations/MigrationExecuteCommand.ts
@@ -1,4 +1,4 @@
-import { Command, CommandConfiguration, Input, validateProjectName, Workspace } from '@contember/cli-common'
+import { Command, CommandConfiguration, Input, Workspace } from '@contember/cli-common'
 import { MigrationsContainerFactory } from '../../MigrationsContainer'
 import {
 	configureExecuteMigrationCommand,
@@ -6,15 +6,13 @@ import {
 	executeMigrations,
 	resolveMigrationStatus,
 } from './MigrationExecuteHelper'
-import { createMigrationStatusTable, findMigration, MigrationState } from '../../utils/migrations'
-import { assertNever } from '../../utils/assertNever'
+import { createMigrationStatusTable } from '../../utils/migrations'
 import { interactiveResolveInstanceEnvironmentFromInput } from '../../utils/instance'
 import { interactiveResolveApiToken, TenantClient } from '../../utils/tenant'
 import { SystemClient } from '../../utils/system'
 
 type Args = {
 	project?: string
-	migration?: string
 }
 
 type Options = ExecuteMigrationOptions & {
@@ -33,7 +31,6 @@ export class MigrationExecuteCommand extends Command<Args, Options> {
 		if (!this.workspace.isSingleProjectMode()) {
 			configuration.argument('project')
 		}
-		configuration.argument('migration').optional()
 		configuration.option('force').description('Ignore migrations order and missing migrations (dev only)')
 		configureExecuteMigrationCommand(configuration)
 	}
@@ -56,7 +53,6 @@ export class MigrationExecuteCommand extends Command<Args, Options> {
 		for (const project of projects) {
 			const migrationsDir = project.migrationsDir
 			const container = new MigrationsContainerFactory(migrationsDir).create()
-			const migrationArg = input.getArgument('migration')
 
 			const instance = await interactiveResolveInstanceEnvironmentFromInput(workspace, input?.getOption('instance'))
 			const apiToken = await interactiveResolveApiToken({ workspace, instance })
@@ -74,28 +70,8 @@ export class MigrationExecuteCommand extends Command<Args, Options> {
 				}
 			}
 
-			const migrations = (() => {
-				if (migrationArg) {
-					const migration = findMigration(status.allMigrations, migrationArg)
-					if (!migration) {
-						throw `Undefined migration ${migrationArg}`
-					}
-					switch (migration.state) {
-						case MigrationState.EXECUTED_OK:
-							throw `Migration ${migrationArg} is already executed`
-						case MigrationState.TO_EXECUTE_ERROR:
-						case MigrationState.EXECUTED_ERROR:
-						case MigrationState.EXECUTED_MISSING:
-							throw `Cannot execute migration ${migrationArg}: ${migration.errorMessage} (${migration.state})`
-						case MigrationState.TO_EXECUTE_OK:
-							return [migration]
-						default:
-							assertNever(migration)
-					}
-				} else {
-					return status.migrationsToExecute
-				}
-			})()
+			const migrations = status.migrationsToExecute
+
 			if (migrations.length === 0) {
 				console.log('No migrations to execute')
 				continue


### PR DESCRIPTION
This pull request introduces a new feature, the '--until' option, into the 'migration:execute' command. This enhancement offers users improved control over their migration execution process by enabling them to specify a particular migration as an endpoint. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/448)
<!-- Reviewable:end -->
