### PR TITLE
acl normalization: deep merge content and system

### DIFF
--- a/packages/schema-utils/src/schemaNormalizer.ts
+++ b/packages/schema-utils/src/schemaNormalizer.ts
@@ -2,6 +2,9 @@ import { Acl, ProjectRole, Schema } from '@contember/schema'
 import { AllowAllPermissionFactory } from './acl'
 
 export const normalizeSchema = <S extends Schema>(schema: S): S => {
+	const adminRoleDefinition: Partial<Acl.RolePermissions> = schema.acl.roles?.[ProjectRole.ADMIN] ?? {}
+	const contentAdminRoleDefinition: Partial<Acl.RolePermissions> = schema.acl.roles?.[ProjectRole.CONTENT_ADMIN] ?? {}
+
 	return {
 		...schema,
 		acl: {
@@ -21,13 +24,15 @@ export const normalizeSchema = <S extends Schema>(schema: S): S => {
 					content: {
 						export: true,
 						import: true,
+						...adminRoleDefinition.content,
 					},
 					system: {
 						export: true,
 						import: true,
+						...adminRoleDefinition.system,
 					},
 					debug: true,
-					...((schema.acl.roles?.[ProjectRole.ADMIN] as Acl.RolePermissions | undefined) || {}),
+					...adminRoleDefinition,
 				},
 				[ProjectRole.CONTENT_ADMIN]: {
 					stages: '*',
@@ -42,13 +47,15 @@ export const normalizeSchema = <S extends Schema>(schema: S): S => {
 					content: {
 						export: true,
 						import: true,
+						...contentAdminRoleDefinition.content,
 					},
 					system: {
 						history: true,
 						export: true,
 						import: true,
+						...contentAdminRoleDefinition.system,
 					},
-					...((schema.acl.roles?.[ProjectRole.CONTENT_ADMIN] as Acl.RolePermissions | undefined) || {}),
+					...contentAdminRoleDefinition,
 				},
 				[ProjectRole.DEPLOYER]: {
 					stages: '*',


### PR DESCRIPTION
This PR preserves the default configuration for system and content sections of ACL configuration for admin and content_admin roles.

-----


**Migration Guide: Changes to ACL Default Merging**

A minor adjustment has been made to the merging of default ACL configurations. Previously, it was possible to disable import/export for the admin and content_admin roles by overriding the content and system ACL configurations. However, this behavior was found to be undesirable as it often led to accidental disabling of import/export when attempting to modify other configurations.

If you relied on this behavior, you will need to make adjustments. 

For example, the following code snippet unintentionally disabled import/export for the admin role:

```javascript
export const adminRole = acl.createRole('admin', {
	content: {
		assumeMembership: { public: true },
	},
	system: {
		assumeIdentity: true,
	},
});
```

If you genuinely wish to disable export/import for the admin role, you must explicitly set `import: false` and `export: false` as shown below:

```javascript
export const adminRole = acl.createRole('admin', {
	content: {
		import: false,
		export: false,
		assumeMembership: { public: true },
	},
	system: {
		import: false,
		export: false,
		assumeIdentity: true,
	},
});
```

Ensure that you review and update your ACL configurations accordingly, explicitly specifying import/export settings as needed. This will help maintain the desired behavior for your admin and content_admin roles while avoiding any unintentional changes caused by the default merging of ACL configurations.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/449)
<!-- Reviewable:end -->
