### PR TITLE
Tenant API: better invite permissions

### DIFF
--- a/packages/engine-tenant-api/tests/cases/unit/authorization/membershipAwareAccessNode.test.ts
+++ b/packages/engine-tenant-api/tests/cases/unit/authorization/membershipAwareAccessNode.test.ts
@@ -11,6 +11,7 @@ const aclSchemaAdminCanManageEditorWithMatchingVariables: Acl.Schema = {
 			entities: {},
 			variables: {},
 			tenant: {
+				invite: true,
 				manage: {
 					editor: {
 						variables: { site: 'site' },
@@ -40,4 +41,39 @@ test('admin can assign editor role with matching variable', async () => {
 test('admin cannot assign editor role with different variable', async () => {
 	const node = new AclSchemaAccessNodeFactory().create(aclSchemaAdminCanManageEditorWithMatchingVariables, adminOfSiteA)
 	assert.notOk(await node.isAllowed(aclEvaluator, PermissionActions.PROJECT_ADD_MEMBER(editorOfSiteB)))
+})
+
+test('admin can invite editor role with matching variable', async () => {
+	const node = new AclSchemaAccessNodeFactory().create(aclSchemaAdminCanManageEditorWithMatchingVariables, adminOfSiteA)
+
+	assert.ok(await node.isAllowed(aclEvaluator, PermissionActions.PERSON_INVITE(editorOfSiteA)))
+})
+
+
+const aclSchemaForInviteOnly: Acl.Schema = {
+	roles: {
+		admin: {
+			entities: {},
+			variables: {},
+			tenant: {
+				invite: {
+					public: true,
+				},
+				manage: {
+					lorem: true,
+				},
+			},
+		},
+	},
+}
+
+
+test('admin can invite public. cannat manage public, cannot invite lorem', async () => {
+	const node = new AclSchemaAccessNodeFactory().create(aclSchemaForInviteOnly, [{ role: 'admin', variables: [] }])
+
+	assert.ok(await node.isAllowed(aclEvaluator, PermissionActions.PERSON_INVITE([{ role: 'public', variables: [] }])))
+
+	assert.notOk(await node.isAllowed(aclEvaluator, PermissionActions.PERSON_INVITE([{ role: 'lorem', variables: [] }])))
+
+	assert.notOk(await node.isAllowed(aclEvaluator, PermissionActions.PROJECT_REMOVE_MEMBER([{ role: 'public', variables: [] }])))
 })

--- a/packages/schema-utils/src/type-schema/acl.ts
+++ b/packages/schema-utils/src/type-schema/acl.ts
@@ -19,8 +19,8 @@ const membershipMatchRuleSchema = Typesafe.record(
 )
 
 const tenantPermissionsSchema = Typesafe.partial({
-	invite: Typesafe.boolean,
-	unmanagedInvite: Typesafe.boolean,
+	invite: Typesafe.union(Typesafe.boolean, membershipMatchRuleSchema),
+	unmanagedInvite: Typesafe.union(Typesafe.boolean, membershipMatchRuleSchema),
 	manage: membershipMatchRuleSchema,
 })
 const tenantSchemaCheck: Typesafe.Equals<Acl.TenantPermissions, ReturnType<typeof tenantPermissionsSchema>> = true

--- a/packages/schema/src/schema/acl.ts
+++ b/packages/schema/src/schema/acl.ts
@@ -101,8 +101,8 @@ export namespace Acl {
 	}
 
 	export type TenantPermissions = {
-		readonly invite?: boolean
-		readonly unmanagedInvite?: boolean
+		readonly invite?: boolean | MembershipMatchRule
+		readonly unmanagedInvite?: boolean | MembershipMatchRule
 		readonly manage?: MembershipMatchRule
 	}
 


### PR DESCRIPTION
This PR introduces new feature that enhances the Access Control List (ACL) permissions for invites. With this enhancement, users can now have more control over invite-related actions and define separate rules for managing memberships.

Previously, the `TenantPermissions` type had properties `invite` and `unmanagedInvite` to determine whether users could invite others. The `manage` property allowed defining rules for managing memberships, including the ability to invite, remove, or view memberships.

Now, the `invite` and `unmanagedInvite` properties can accept either a simple boolean value or a more detailed rule object. This change enables users to set individual rules for invite actions, distinct from the rules for managing memberships. For example, you can allow users with specific roles to create invites while restricting their ability to remove or view memberships.

The update also maintains backward compatibility. If `invite` is set to `true`, it will continue to use the existing `manage` rules. However, if a `MembershipMatchRule` object is provided for `invite`, it will override the `manage` rules for invite-related permissions, giving users the freedom to define custom rules for invites.


### Example:
```
export const publicInviteRole = acl.createRole('publicInvite', {
	tenant: {
		invite: {
			public: true,
		}
	},
})

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/450)
<!-- Reviewable:end -->
