### PR TITLE
migrations: allow to copyValue/fillValue when updating column definition

### DIFF
--- a/packages/schema-migrations/src/modifications/columns/CreateColumnModification.ts
+++ b/packages/schema-migrations/src/modifications/columns/CreateColumnModification.ts
@@ -1,5 +1,5 @@
 import { escapeValue, MigrationBuilder } from '@contember/database-migrations'
-import { Model, Schema } from '@contember/schema'
+import { JSONValue, Model, Schema } from '@contember/schema'
 import { addField, SchemaUpdater, updateEntity, updateModel } from '../utils/schemaUpdateUtils'
 import { createModificationType, Differ, ModificationHandler } from '../ModificationHandler'
 import { wrapIdentifier } from '../../utils/dbHelpers'
@@ -67,7 +67,7 @@ export class CreateColumnModificationHandler implements ModificationHandler<Crea
 export interface CreateColumnModificationData {
 	entityName: string
 	field: Model.AnyColumn
-	fillValue?: any
+	fillValue?: JSONValue
 	copyValue?: string
 }
 

--- a/packages/schema-migrations/src/modifications/columns/CreateColumnModification.ts
+++ b/packages/schema-migrations/src/modifications/columns/CreateColumnModification.ts
@@ -37,10 +37,6 @@ export class CreateColumnModificationHandler implements ModificationHandler<Crea
 				throw new ImplementationException()
 			}
 
-			// event applier defers constraint check, we need to fire them before ALTER
-			builder.sql(`SET CONSTRAINTS ALL IMMEDIATE`)
-			builder.sql(`SET CONSTRAINTS ALL DEFERRED`)
-
 			if (!column.nullable) {
 				builder.alterColumn(entity.tableName, column.columnName, {
 					notNull: true,

--- a/packages/schema-migrations/src/modifications/columns/columnUtils.ts
+++ b/packages/schema-migrations/src/modifications/columns/columnUtils.ts
@@ -1,0 +1,35 @@
+import { wrapIdentifier } from '../../utils/dbHelpers'
+import { ImplementationException } from '../../exceptions'
+import { JSONValue, Model } from '@contember/schema'
+import { escapeValue, MigrationBuilder } from '@contember/database-migrations'
+import { getColumnName } from '@contember/schema-utils'
+
+export const fillSeed = ({ builder, fillValue, copyValue, entity, columnName, nullable, model, columnType, type }: {
+	model: Model.Schema
+	entity: Model.Entity
+	columnName: string
+	columnType: string
+	nullable: boolean
+	builder: MigrationBuilder
+	fillValue?: JSONValue
+	copyValue?: string
+	type: 'creating' | 'updating'
+}) => {
+	const where = type === 'updating' ? ` WHERE ${wrapIdentifier(columnName)} IS NULL` : ''
+	if (fillValue !== undefined) {
+		builder.sql(`UPDATE ${wrapIdentifier(entity.tableName)}
+                     SET ${wrapIdentifier(columnName)} = ${escapeValue(fillValue)}${where}`)
+	} else if (copyValue !== undefined) {
+		const copyFrom = getColumnName(model, entity, copyValue)
+		builder.sql(`UPDATE ${wrapIdentifier(entity.tableName)}
+                     SET ${wrapIdentifier(columnName)} = ${wrapIdentifier(copyFrom)}::${columnType}${where}`)
+	} else {
+		throw new ImplementationException()
+	}
+
+	if (!nullable) {
+		builder.alterColumn(entity.tableName, columnName, {
+			notNull: true,
+		})
+	}
+}

--- a/packages/schema-migrations/tests/cases/integration/createColumn.test.ts
+++ b/packages/schema-migrations/tests/cases/integration/createColumn.test.ts
@@ -32,7 +32,6 @@ testMigrations('create a column with default value', {
 	],
 	sql: SQL`ALTER TABLE "author" ADD "name" text;
 UPDATE "author" SET "name" = $pga$unnamed author$pga$;
-SET CONSTRAINTS ALL IMMEDIATE; SET CONSTRAINTS ALL DEFERRED;
 ALTER TABLE "author" ALTER "name" SET NOT NULL;`,
 })
 
@@ -65,6 +64,5 @@ testMigrations('create a column with copy value', {
 	noDiff: true,
 	sql: SQL`ALTER TABLE "author" ADD "name" text;
 UPDATE "author" SET "name" = "email"::text;
-SET CONSTRAINTS ALL IMMEDIATE; SET CONSTRAINTS ALL DEFERRED;
 ALTER TABLE "author" ALTER "name" SET NOT NULL;`,
 })

--- a/packages/schema-migrations/tests/cases/integration/updateColumnDefinition.test.ts
+++ b/packages/schema-migrations/tests/cases/integration/updateColumnDefinition.test.ts
@@ -168,3 +168,35 @@ ALTER TABLE "author"
 CREATE VIEW "author_meta_x" AS SELECT * FROM author;
 CREATE VIEW "author_meta_y" AS SELECT * FROM author_meta_x;`,
 })
+
+
+namespace NotNullOrig {
+	export class Author {
+		name = def.stringColumn()
+	}
+}
+namespace NotNullUpdated {
+	export class Author {
+		name = def.stringColumn().notNull()
+	}
+}
+testMigrations('set not null and fill', {
+	originalSchema: createSchema(NotNullOrig).model,
+	updatedSchema: createSchema(NotNullUpdated).model,
+	noDiff: true,
+	diff: [
+		updateColumnDefinitionModification.createModification({
+			entityName: 'Author',
+			fieldName: 'name',
+			definition: {
+				type: Model.ColumnType.String,
+				columnType: 'text',
+				nullable: false,
+			},
+			fillValue: 'unnamed',
+		}),
+	],
+	sql: SQL`
+UPDATE "author" SET "name" = $pga$unnamed$pga$ WHERE "name" IS NULL; 
+ALTER TABLE "author" ALTER "name" SET NOT NULL;`,
+})


### PR DESCRIPTION
This pull request enhances the migration functionality in Contember by introducing the fillValue and copyValue options to the `updateSchemaDefinition` operation. The existing `createColumn` modification already supports these options, and this update extends their usage to the `updateColumnDefinition` operation as well.

The `fillValue`/`copyValue` option allows the migration to fill the modified column with a specific value during the migration run. Unlike the default value used at runtime, the fillValue is exclusively used during the migration process.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/451)
<!-- Reviewable:end -->
