### PR TITLE
CLI: deploy custom frontend, allow deployment without frontend (admin) deploy

### DIFF
--- a/packages/cli/src/commands/deploy/DeployCommand.ts
+++ b/packages/cli/src/commands/deploy/DeployCommand.ts
@@ -1,4 +1,4 @@
-import { Command, CommandConfiguration, Input, pathExists, Project, Workspace } from '@contember/cli-common'
+import { Command, CommandConfiguration, Input, pathExists, Workspace } from '@contember/cli-common'
 import {
 	configureExecuteMigrationCommand,
 	ExecuteMigrationOptions,
@@ -10,7 +10,6 @@ import { interactiveResolveInstanceEnvironmentFromInput } from '../../utils/inst
 import { SystemClient } from '../../utils/system'
 import { MigrationsContainerFactory } from '../../MigrationsContainer'
 import { AdminClient, readAdminFiles } from '../../utils/admin'
-import { URL } from 'node:url'
 import prompts from 'prompts'
 import { createMigrationStatusTable } from '../../utils/migrations'
 import { maskToken } from '../../utils/token'
@@ -23,6 +22,8 @@ type Args = {
 
 type Options = ExecuteMigrationOptions & {
 	admin?: string
+	['no-admin']?: boolean
+	root?: boolean
 }
 
 export class DeployCommand extends Command<Args, Options> {
@@ -35,10 +36,15 @@ export class DeployCommand extends Command<Args, Options> {
 	protected configure(configuration: CommandConfiguration<Args, Options>): void {
 		configuration.description('Deploy Contember project')
 		configuration.argument('dsn')
+
 		if (!this.workspace.isSingleProjectMode()) {
 			configuration.argument('project').optional()
 		}
+
 		configuration.option('admin').valueRequired()
+		configuration.option('no-admin').valueNone()
+		configuration.option('root').valueNone()
+
 		configureExecuteMigrationCommand(configuration)
 	}
 
@@ -120,13 +126,20 @@ export class DeployCommand extends Command<Args, Options> {
 			return migrationExitCode
 		}
 
-		if (adminEndpoint) {
+		if (adminEndpoint && input.getOption('no-admin') !== true) {
 			console.log('Deploying admin...')
 			const client = AdminClient.create(adminEndpoint, apiToken)
 			const files = await readAdminFiles(projectAdminDistDir)
-			await client.deploy(remoteProject, files)
+
+			// in some cases you need deploy whole folder with custom build etc.
+			// with root option you can build app on your own and simply deploy it with subprojects
+			await client.deploy(
+				input.getOption('root') ? null : remoteProject, files,
+			)
+
 			console.log(`Admin deployed (${files.length} files)`)
 		}
+
 		console.log('')
 		console.log('Deployment successful')
 		console.log(`API URL: ${instance.baseUrl}`)

--- a/packages/cli/src/utils/admin.ts
+++ b/packages/cli/src/utils/admin.ts
@@ -9,7 +9,7 @@ export class AdminClient {
 		return new AdminClient(url, apiToken)
 	}
 
-	public async deploy(project: string, files: AdminFiles): Promise<void> {
+	public async deploy(project: string | null, files: AdminFiles): Promise<void> {
 		const response = await this.execute('_deploy', 'POST', { project, files })
 
 		if (!response.ok) {

--- a/packages/engine-tenant-api/src/model/authorization/PermissionActions.ts
+++ b/packages/engine-tenant-api/src/model/authorization/PermissionActions.ts
@@ -4,6 +4,7 @@ import { Acl } from '@contember/schema'
 namespace PermissionActions {
 	export enum Resources {
 		system = 'system',
+		entrypoint = 'entrypoint',
 		person = 'person',
 		identity = 'identity',
 		project = 'project',
@@ -37,6 +38,7 @@ namespace PermissionActions {
 	export const PROJECT_UPDATE = Authorizator.createAction(Resources.project, 'update')
 
 	export const PROJECT_CREATE = Authorizator.createAction(Resources.project, 'create')
+	export const ENTRYPOINT_DEPLOY = Authorizator.createAction(Resources.entrypoint, 'deployEntrypoint')
 
 	export const PROJECT_VIEW_MEMBER = (memberships: readonly Acl.Membership[]) => Authorizator.createAction(Resources.project, 'viewMembers', { memberships })
 	export const PROJECT_ADD_MEMBER = (memberships: readonly Acl.Membership[]) => Authorizator.createAction(Resources.project, 'addMember', { memberships })

--- a/packages/engine-tenant-api/src/model/authorization/PermissionsFactory.ts
+++ b/packages/engine-tenant-api/src/model/authorization/PermissionsFactory.ts
@@ -2,7 +2,7 @@ import { Permissions } from '@contember/authorization'
 import { PermissionActions } from './PermissionActions'
 import { TenantRole } from './Roles'
 
-const allowedRoles = new Set<string>([TenantRole.LOGIN, TenantRole.PROJECT_ADMIN])
+const allowedRoles = new Set<string>([TenantRole.LOGIN, TenantRole.PROJECT_ADMIN, TenantRole.ENTRYPOINT_DEPLOYER])
 
 const projectAdminAllowedInputRoles = ({ roles }: {roles?: readonly string[]}) => {
 	return roles === undefined || roles.every(it => allowedRoles.has(it))
@@ -58,7 +58,10 @@ class PermissionsFactory {
 		permissions.allow(TenantRole.PROJECT_ADMIN, PermissionActions.IDP_DISABLE)
 		permissions.allow(TenantRole.PROJECT_ADMIN, PermissionActions.IDP_ENABLE)
 
+		permissions.allow(TenantRole.PROJECT_ADMIN, PermissionActions.ENTRYPOINT_DEPLOY)
+
 		permissions.allow(TenantRole.PROJECT_CREATOR, PermissionActions.PROJECT_CREATE)
+		permissions.allow(TenantRole.ENTRYPOINT_DEPLOYER, PermissionActions.ENTRYPOINT_DEPLOY)
 
 		return permissions
 	}

--- a/packages/engine-tenant-api/src/model/authorization/Roles.ts
+++ b/packages/engine-tenant-api/src/model/authorization/Roles.ts
@@ -6,4 +6,5 @@ export enum TenantRole {
 	PROJECT_CREATOR = 'project_creator',
 	PROJECT_MEMBER = 'project_member',
 	PROJECT_ADMIN = 'project_admin',
+	ENTRYPOINT_DEPLOYER = 'entrypoint_deployer',
 }

--- a/packages/engine-tenant-api/src/resolvers/types/IdentityTypeResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/types/IdentityTypeResolver.ts
@@ -117,6 +117,7 @@ export class IdentityTypeResolver implements IdentityResolvers {
 		if (parent.permissions) {
 			return parent.permissions
 		}
+
 		const permissionsContext = await (async () => {
 			const isSelf = parent.id === context.identity.id
 			if (isSelf) {
@@ -128,13 +129,14 @@ export class IdentityTypeResolver implements IdentityResolvers {
 			}
 			return this.permissionContextFactory.create(context.db, { id: parent.id, roles })
 		})()
+
 		if (!permissionsContext) {
 			return null
 		}
+
 		return {
 			canCreateProject: await permissionsContext.isAllowed({ action: PermissionActions.PROJECT_CREATE }),
+			canDeployEntrypoint: await permissionsContext.isAllowed({ action: PermissionActions.ENTRYPOINT_DEPLOY }),
 		}
 	}
-
-
 }

--- a/packages/engine-tenant-api/src/schema/index.ts
+++ b/packages/engine-tenant-api/src/schema/index.ts
@@ -405,6 +405,7 @@ export type Identity = {
 export type IdentityGlobalPermissions = {
 	readonly __typename?: 'IdentityGlobalPermissions'
 	readonly canCreateProject: Scalars['Boolean']
+	readonly canDeployEntrypoint: Scalars['Boolean']
 }
 
 export type IdentityProjectRelation = {
@@ -1812,6 +1813,7 @@ export type IdentityResolvers<ContextType = any, ParentType extends ResolversPar
 
 export type IdentityGlobalPermissionsResolvers<ContextType = any, ParentType extends ResolversParentTypes['IdentityGlobalPermissions'] = ResolversParentTypes['IdentityGlobalPermissions']> = {
 	canCreateProject?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
+	canDeployEntrypoint?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 

--- a/packages/engine-tenant-api/src/schema/tenant.graphql.ts
+++ b/packages/engine-tenant-api/src/schema/tenant.graphql.ts
@@ -72,9 +72,9 @@ const schema: DocumentNode = gql`
 
 		updateProjectMember(projectSlug: String!, identityId: String!, memberships: [MembershipInput!]!): UpdateProjectMemberResponse
 
-        createApiKey(projectSlug: String!, memberships: [MembershipInput!]!, description: String!, tokenHash: String): CreateApiKeyResponse
-        createGlobalApiKey(description: String!, roles: [String!], tokenHash: String): CreateApiKeyResponse
-        disableApiKey(id: String!): DisableApiKeyResponse
+		createApiKey(projectSlug: String!, memberships: [MembershipInput!]!, description: String!, tokenHash: String): CreateApiKeyResponse
+		createGlobalApiKey(description: String!, roles: [String!], tokenHash: String): CreateApiKeyResponse
+		disableApiKey(id: String!): DisableApiKeyResponse
 		addGlobalIdentityRoles(identityId: String!, roles: [String!]!): AddGlobalIdentityRolesResponse
 		removeGlobalIdentityRoles(identityId: String!, roles: [String!]!): RemoveGlobalIdentityRolesResponse
 
@@ -532,9 +532,9 @@ const schema: DocumentNode = gql`
 		endUserMessage: String @deprecated
 	}
 
-    enum DisableApiKeyErrorCode {
-        KEY_NOT_FOUND
-    }
+	enum DisableApiKeyErrorCode {
+		KEY_NOT_FOUND
+	}
 	# === addGlobalIdentityRoles ===
 
 	type AddGlobalIdentityRolesResponse {
@@ -574,10 +574,10 @@ const schema: DocumentNode = gql`
 		identity: Identity!
 	}
 
-    enum RemoveGlobalIdentityRolesErrorCode {
-        IDENTITY_NOT_FOUND
-        INVALID_ROLE
-    }
+	enum RemoveGlobalIdentityRolesErrorCode {
+		IDENTITY_NOT_FOUND
+		INVALID_ROLE
+	}
 	# === common ===
 
 	# === variables ===

--- a/packages/engine-tenant-api/src/schema/tenant.graphql.ts
+++ b/packages/engine-tenant-api/src/schema/tenant.graphql.ts
@@ -72,9 +72,9 @@ const schema: DocumentNode = gql`
 
 		updateProjectMember(projectSlug: String!, identityId: String!, memberships: [MembershipInput!]!): UpdateProjectMemberResponse
 
-		createApiKey(projectSlug: String!, memberships: [MembershipInput!]!, description: String!, tokenHash: String): CreateApiKeyResponse
-		createGlobalApiKey(description: String!, roles: [String!], tokenHash: String): CreateApiKeyResponse
-		disableApiKey(id: String!): DisableApiKeyResponse
+        createApiKey(projectSlug: String!, memberships: [MembershipInput!]!, description: String!, tokenHash: String): CreateApiKeyResponse
+        createGlobalApiKey(description: String!, roles: [String!], tokenHash: String): CreateApiKeyResponse
+        disableApiKey(id: String!): DisableApiKeyResponse
 		addGlobalIdentityRoles(identityId: String!, roles: [String!]!): AddGlobalIdentityRolesResponse
 		removeGlobalIdentityRoles(identityId: String!, roles: [String!]!): RemoveGlobalIdentityRolesResponse
 
@@ -532,9 +532,9 @@ const schema: DocumentNode = gql`
 		endUserMessage: String @deprecated
 	}
 
-	enum DisableApiKeyErrorCode {
-		KEY_NOT_FOUND
-	}
+    enum DisableApiKeyErrorCode {
+        KEY_NOT_FOUND
+    }
 	# === addGlobalIdentityRoles ===
 
 	type AddGlobalIdentityRolesResponse {
@@ -546,7 +546,6 @@ const schema: DocumentNode = gql`
 	type AddGlobalIdentityRolesResult {
 		identity: Identity!
 	}
-
 	type AddGlobalIdentityRolesError {
 		code: AddGlobalIdentityRolesErrorCode!
 		developerMessage: String!
@@ -575,10 +574,10 @@ const schema: DocumentNode = gql`
 		identity: Identity!
 	}
 
-	enum RemoveGlobalIdentityRolesErrorCode {
-		IDENTITY_NOT_FOUND
-		INVALID_ROLE
-	}
+    enum RemoveGlobalIdentityRolesErrorCode {
+        IDENTITY_NOT_FOUND
+        INVALID_ROLE
+    }
 	# === common ===
 
 	# === variables ===
@@ -655,6 +654,7 @@ const schema: DocumentNode = gql`
 
 	type IdentityGlobalPermissions {
 		canCreateProject: Boolean!
+		canDeployEntrypoint: Boolean!
 	}
 
 	type IdentityProjectRelation {


### PR DESCRIPTION
This PR brings few features related to a custom "entrypoint" deployment on admin server:
- allow to skip admin / migrations in deploy command
- add canDeployEntrypoint to IdentityGlobalPermissions in tenant API


Related PR: https://github.com/contember/interface/pull/561

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/456)
<!-- Reviewable:end -->
