### PR TITLE
internal: fix snapshot migrations time prefix

### DIFF
--- a/packages/database-migrations/package.json
+++ b/packages/database-migrations/package.json
@@ -2,7 +2,7 @@
   "name": "@contember/database-migrations",
   "version": "1.3.0-rc.1",
   "scripts": {
-    "test": "echo 'No tests'"
+    "test": "vitest --dir ./tests/cases"
   },
   "license": "Apache-2.0",
   "main": "dist/src/index.js",

--- a/packages/database-migrations/src/GroupMigrationsResolver.ts
+++ b/packages/database-migrations/src/GroupMigrationsResolver.ts
@@ -1,5 +1,6 @@
 import { MigrationsResolver, MigrationsResolverContext } from './MigrationsResolver'
 import { Migration } from './Migration'
+import { timePrefixLength } from './helpers'
 
 export class GroupMigrationsResolver<Args> implements MigrationsResolver<Args> {
 	constructor(
@@ -8,20 +9,31 @@ export class GroupMigrationsResolver<Args> implements MigrationsResolver<Args> {
 	) {
 	}
 
-	resolveMigrations({ runMigrations, createTimeVersionPrefix }: MigrationsResolverContext): Migration<Args>[] {
+	resolveMigrations({ runMigrations }: MigrationsResolverContext): Migration<Args>[] {
 		const allMigrations: Migration<Args>[] = []
 		const primaryMigrations = this.primaryGroup.resolveMigrations({
 			runMigrations: runMigrations.filter(it => it.group === null),
-			createTimeVersionPrefix,
 		})
 		allMigrations.push(...primaryMigrations)
 		for (const groupName in this.groups) {
 			const groupMigrations = this.groups[groupName].resolveMigrations({
-				createTimeVersionPrefix,
 				runMigrations: runMigrations.filter(it => it.group === groupName),
 			}).map(it => new Migration(it.name, it.migration, groupName))
 			allMigrations.push(...groupMigrations)
 		}
-		return allMigrations.sort((a, b) => a.name.localeCompare(b.name))
+		return allMigrations.sort((a, b) => {
+			const compareResult = a.name.slice(0, timePrefixLength).localeCompare(b.name.slice(0, timePrefixLength))
+			if (compareResult !== 0) {
+				return compareResult
+			}
+			// if the time is same, prefer primary group
+			if (a.group === null) {
+				return -1
+			}
+			if (b.group === null) {
+				return 1
+			}
+			return a.group.localeCompare(b.group) || a.name.localeCompare(b.name)
+		})
 	}
 }

--- a/packages/database-migrations/src/MigrationsResolver.ts
+++ b/packages/database-migrations/src/MigrationsResolver.ts
@@ -2,7 +2,6 @@ import { Migration, RunMigration } from './Migration'
 
 export interface MigrationsResolverContext {
 	runMigrations: RunMigration[]
-	createTimeVersionPrefix: () => string
 }
 export interface MigrationsResolver<Args> {
 	resolveMigrations(ctx: MigrationsResolverContext): Migration<Args>[]

--- a/packages/database-migrations/src/SnapshotMigrationResolver.ts
+++ b/packages/database-migrations/src/SnapshotMigrationResolver.ts
@@ -1,4 +1,4 @@
-import { Migration, MigrationExecutor } from './Migration'
+import { Migration, MigrationExecutor, RunMigration } from './Migration'
 import { MigrationsResolver, MigrationsResolverContext } from './MigrationsResolver'
 import { checkOrder, timePrefixLength } from './helpers'
 
@@ -7,28 +7,63 @@ export class SnapshotMigrationResolver<Args> implements MigrationsResolver<Args>
 		private snapshot: MigrationExecutor<Args>,
 		private migrations: Record<string, MigrationExecutor<Args>>,
 		private suffix: string = 'snapshot',
+		private baseMigrations?: Record<string, MigrationExecutor<Args>>,
 	) {
 	}
 
 	resolveMigrations(
-		{ runMigrations, createTimeVersionPrefix }: MigrationsResolverContext,
+		{ runMigrations }: MigrationsResolverContext,
 	): Migration<Args>[] {
-		// runMigrations = runMigrations.filter(it => it.group === group)
-		if (runMigrations.length === 0 && !process.env.CONTEMBER_MIGRATIONS_NO_SNAPSHOT) {
-			const timePrefix = createTimeVersionPrefix()
-			return [new Migration<Args>(`${timePrefix}-${this.suffix}`, this.snapshot)]
+
+		if (this.canUseSnapshot(runMigrations)) {
+			return this.getSnapshotMigration()
 		}
 
-		const migrations = Object.entries(this.migrations).map(([version, executor]) => new Migration<Args>(version, executor))
-		const resolvedMigrations = runMigrations.length > 0 && runMigrations[0].name.slice(timePrefixLength) === `-${this.suffix}`
-			? [
-				new Migration<Args>(runMigrations[0].name, this.snapshot),
-				...migrations.filter(it => it.name > runMigrations[0].name),
-			]
-			: migrations
+		const resolvedMigrations = this.getEffectiveMigrations(runMigrations)
 
 		checkOrder(runMigrations, resolvedMigrations)
 
 		return resolvedMigrations
+	}
+
+	private canUseSnapshot(runMigrations: RunMigration[]): boolean {
+		return runMigrations.length === 0 && !process.env.CONTEMBER_MIGRATIONS_NO_SNAPSHOT
+	}
+
+	private getSnapshotMigration(): Migration<Args>[] {
+		const migrations = Object.keys(this.migrations)
+		const baseMigrations = Object.keys(this.baseMigrations ?? {})
+
+		const lastMigration = migrations[migrations.length - 1]?.slice(0, timePrefixLength)
+		const lastBaseMigration = baseMigrations[baseMigrations.length - 1]?.slice(0, timePrefixLength)
+
+		const fallback = '0000-00-00-000000'
+		// time prefix matches latest base or current group migration
+		const timePrefix = lastMigration && lastBaseMigration
+			? (lastMigration > lastBaseMigration ? lastMigration : lastBaseMigration)
+			: (lastMigration ?? lastBaseMigration ?? fallback)
+
+		return [
+			new Migration<Args>(`${timePrefix}-${this.suffix}`, this.snapshot),
+		]
+	}
+
+	private getEffectiveMigrations(runMigrations: RunMigration[]): Migration<Args>[] {
+		const migrations = Object.entries(this.migrations).map(([version, executor]) => new Migration<Args>(version, executor))
+
+		const wasSnapshotExecuted = runMigrations.length > 0
+			&& runMigrations[0]?.name.slice(timePrefixLength) === `-${this.suffix}`
+
+		if (!wasSnapshotExecuted) {
+			return migrations
+		}
+
+		const executedSnapshotMigration = new Migration<Args>(runMigrations[0].name, this.snapshot)
+		const minVersion = runMigrations[0].name.slice(0, timePrefixLength)
+
+		return [
+			executedSnapshotMigration,
+			...migrations.filter(it => it.name.slice(0, timePrefixLength) > minVersion),
+		]
 	}
 }

--- a/packages/database-migrations/src/helpers.ts
+++ b/packages/database-migrations/src/helpers.ts
@@ -22,26 +22,6 @@ export function escapeValue(value: any): any {
 
 export const timePrefixLength = 'YYYY-MM-DD-XXXXXX'.length
 
-
-export const createMigrationVersionPrefixGenerator = () => {
-	let inc = 0
-	const date = new Date()
-	return () => createMigrationVersionTimePrefix(date, inc++)
-}
-
-const createMigrationVersionTimePrefix = (date: Date, increment: number) => {
-	const now = new Date(date)
-	now.setSeconds(now.getSeconds() + increment)
-	const year = now.getFullYear()
-	const month = (now.getMonth() + 1).toString().padStart(2, '0')
-	const day = now.getDate().toString().padStart(2, '0')
-	const hours = now.getHours().toString().padStart(2, '0')
-	const minutes = now.getMinutes().toString().padStart(2, '0')
-	const seconds = now.getSeconds().toString().padStart(2, '0')
-
-	return `${year}-${month}-${day}-${hours}${minutes}${seconds}`
-}
-
 export const checkOrder = (runMigrations: RunMigration[], migrations: Migration<any>[]) => {
 	const len = Math.min(runMigrations.length, migrations.length)
 	for (let i = 0; i < len; i++) {

--- a/packages/database-migrations/src/runner.ts
+++ b/packages/database-migrations/src/runner.ts
@@ -28,7 +28,6 @@ SOFTWARE.
 
 import {
 	createMigrationBuilder,
-	createMigrationVersionPrefixGenerator,
 } from './helpers'
 import { Connection, withDatabaseAdvisoryLock, wrapIdentifier } from '@contember/database'
 import { Migration, RunMigration } from './Migration'
@@ -92,7 +91,6 @@ export default async <Args>(
 			const runMigrations = await getRunMigrations(db, options)
 			const migrations = await migrationsResolver.resolveMigrations({
 				runMigrations,
-				createTimeVersionPrefix: createMigrationVersionPrefixGenerator(),
 			})
 
 			const runNames = runMigrations.map(it => it.name)

--- a/packages/database-migrations/tests/cases/unit/groupMigrationResolver.test.ts
+++ b/packages/database-migrations/tests/cases/unit/groupMigrationResolver.test.ts
@@ -1,0 +1,64 @@
+import { assert, describe, test } from 'vitest'
+import { GroupMigrationsResolver, Migration } from '../../../src'
+
+describe('group migration resolver', () => {
+
+	test('merges migrations', () => {
+		const runner = () => null
+		const resolver = new GroupMigrationsResolver({
+			resolveMigrations: () => [new Migration('2023-07-26-104000-xyz', runner, null)],
+		}, {
+			someGroup: {
+				resolveMigrations: () => [new Migration('2023-07-26-104001-abcd', runner, null)],
+			},
+		})
+		assert.deepEqual(resolver.resolveMigrations({ runMigrations: [] }), [
+			new Migration('2023-07-26-104000-xyz', runner, null),
+			new Migration('2023-07-26-104001-abcd', runner, 'someGroup'),
+		])
+	})
+
+	test('sort migrations with same timestamp', () => {
+		const resolver = new GroupMigrationsResolver({
+			resolveMigrations: () => [new Migration('2023-07-26-104000-xyz', () => null, null)],
+		}, {
+			someGroup: {
+				resolveMigrations: () => [new Migration('2023-07-26-104000-abcd', () => null, null)],
+			},
+		})
+		assert.deepEqual(resolver.resolveMigrations({ runMigrations: [] }).map(it => it.name), [
+			'2023-07-26-104000-xyz',
+			'2023-07-26-104000-abcd',
+		])
+	})
+
+	test('pass correct run migrations', () => {
+		let baseRunMigrations
+		let groupRunMigrations
+		const resolver = new GroupMigrationsResolver({
+			resolveMigrations: ({ runMigrations }) => {
+				baseRunMigrations = runMigrations
+				return []
+			},
+		}, {
+			someGroup: {
+				resolveMigrations: ({ runMigrations }) => {
+					groupRunMigrations = runMigrations
+					return []
+				},
+			},
+		})
+		resolver.resolveMigrations({
+			runMigrations: [
+				{ name: 'abc', group: null },
+				{ name: 'xyz', group: 'someGroup' },
+			],
+		})
+		assert.deepEqual(baseRunMigrations, [
+			{ name: 'abc', group: null },
+		])
+		assert.deepEqual(groupRunMigrations, [
+			{ name: 'xyz', group: 'someGroup' },
+		])
+	})
+})

--- a/packages/database-migrations/tests/cases/unit/snapshotMigrationResolver.test.ts
+++ b/packages/database-migrations/tests/cases/unit/snapshotMigrationResolver.test.ts
@@ -1,0 +1,65 @@
+import { assert, describe, test } from 'vitest'
+import { SnapshotMigrationResolver, Migration } from '../../../src'
+
+describe('snapshot migration resolver', () => {
+	test('use snapshot with latest migration timestamp', () => {
+		const snapshotRunner = () => null
+		const resolver = new SnapshotMigrationResolver(snapshotRunner, {
+			'2023-07-26-105000-xx': () => null,
+			'2023-07-26-105500-yy': () => null,
+		})
+
+		assert.deepEqual(resolver.resolveMigrations({ runMigrations: [] }), [
+			new Migration('2023-07-26-105500-snapshot', snapshotRunner),
+		])
+	})
+
+	test('use snapshot with latest base migration timestamp', () => {
+		const snapshotRunner = () => null
+		const resolver = new SnapshotMigrationResolver(snapshotRunner, {
+			'2023-07-26-105000-xx': () => null,
+			'2023-07-26-105500-yy': () => null,
+		}, 'snapshot', {
+			'2023-07-26-105000-xx': () => null,
+			'2023-07-26-105700-yy': () => null,
+		})
+
+		assert.deepEqual(resolver.resolveMigrations({ runMigrations: [] }), [
+			new Migration('2023-07-26-105700-snapshot', snapshotRunner),
+		])
+	})
+
+	test('do not use snapshot if some migrations are executed, but not a snapshot', () => {
+		const snapshotRunner = () => null
+		const yyRunner = () => null
+		const xxRunner = () => null
+		const resolver = new SnapshotMigrationResolver(snapshotRunner, {
+			'2023-07-26-105000-xx': xxRunner,
+			'2023-07-26-105500-yy': yyRunner,
+		})
+
+		assert.deepEqual(resolver.resolveMigrations({ runMigrations: [{ name: '2023-07-26-105000-xx', group: null }] }), [
+			new Migration('2023-07-26-105000-xx', xxRunner),
+			new Migration('2023-07-26-105500-yy', yyRunner),
+		])
+	})
+
+
+	test('merge snapshot with new migrations', () => {
+		const snapshotRunner = () => null
+		const yyRunner = () => null
+		const xxRunner = () => null
+		const zzRunner = () => null
+		const resolver = new SnapshotMigrationResolver(snapshotRunner, {
+			'2023-07-26-105000-xx': xxRunner,
+			'2023-07-26-105500-yy': yyRunner,
+			'2023-07-26-105700-zz': zzRunner,
+		})
+
+		assert.deepEqual(resolver.resolveMigrations({ runMigrations: [{ name: '2023-07-26-105000-snapshot', group: null }] }), [
+			new Migration('2023-07-26-105000-snapshot', snapshotRunner),
+			new Migration('2023-07-26-105500-yy', yyRunner),
+			new Migration('2023-07-26-105700-zz', zzRunner),
+		])
+	})
+})

--- a/packages/engine-system-api/src/migrations/runner.ts
+++ b/packages/engine-system-api/src/migrations/runner.ts
@@ -69,7 +69,17 @@ export class SystemMigrationsRunner {
 			}
 			const migrationResolver = new GroupMigrationsResolver(
 				new SnapshotMigrationResolver(snapshot, migrations),
-				Object.fromEntries(Object.entries(this.migrationGroups).map(([group, it]) => [group, new SnapshotMigrationResolver(it.snapshot, it.migrations, group.replace(/[^-_\w]+/g, '-'))])),
+				Object.fromEntries(Object.entries(this.migrationGroups).map(
+					([group, it]) => [
+						group,
+						new SnapshotMigrationResolver(
+							it.snapshot,
+							it.migrations,
+							group.replace(/[^-_\w]+/g, '-'),
+							migrations,
+						),
+					]),
+				),
 			)
 			const migrationsRunner = new DbMigrationsRunner(connection, this.schema, migrationResolver)
 			await migrationsRunner.migrate(message => logger.warn(message), {


### PR DESCRIPTION
Previously, the migration runner utilized the current time as a prefix for the snapshot migraton. However, a problem arose when a new migration existed in the new engine version but was created before the execution of the snapshot migration in the engine instance. Consequently, the new migration was inadvertently skipped after the engine was upgraded.

This PR resolves the problem by using the timestamp of the latest known migration instead of relying on the current time.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/459)
<!-- Reviewable:end -->
