### PR TITLE
cli: fix finding package.json/docker-compose

### DIFF
--- a/packages/cli/src/utils/dockerCompose.ts
+++ b/packages/cli/src/utils/dockerCompose.ts
@@ -1,4 +1,4 @@
-import { join } from 'node:path'
+import { join, dirname } from 'node:path'
 import { pathExists } from '@contember/cli-common'
 import { JsonUpdateCallback, updateYaml } from './yaml'
 import jsyaml from 'js-yaml'
@@ -38,7 +38,10 @@ export const resolveMainDockerComposeConfig = async (dir: string): Promise<strin
 export const tryReadMainDockerComposeConfig = async (dir: string): Promise<DockerComposeConfig | null> => {
 	const path = await resolveMainDockerComposeConfig(dir)
 	if (!path) {
-		return null
+		if (dir === '/') {
+			return null
+		}
+		return await tryReadMainDockerComposeConfig(dirname(dir))
 	}
 	return jsyaml.load(await fs.readFile(path, 'utf8')) as DockerComposeConfig
 }


### PR DESCRIPTION
The new version mismatch check dit not work well when a contember was inside subfolder of a monorepo. this fixes the issue by scanning parent folders of cwd

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/460)
<!-- Reviewable:end -->
