### PR TITLE
fix http error code for some graphql validations

### DIFF
--- a/packages/engine-http/src/graphql/execution.ts
+++ b/packages/engine-http/src/graphql/execution.ts
@@ -133,7 +133,7 @@ export const createGraphQLQueryHandler = <Context>({
 			})
 			if (response.errors && response.errors.length > 0) {
 				const [code, errors] = processErrors(response.errors)
-				respond(code && response.data === null ? code : 200, { ...response, errors })
+				respond(code && !response.data ? code : 200, { ...response, errors })
 			} else {
 				respond(200, response)
 			}


### PR DESCRIPTION
When a graphql `execute` fails to build an execution context, it returns an object with no `data` key.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/464)
<!-- Reviewable:end -->
