### PR TITLE
make invitation expiration configurable

### DIFF
--- a/packages/engine-tenant-api/src/TenantContainer.ts
+++ b/packages/engine-tenant-api/src/TenantContainer.ts
@@ -183,8 +183,8 @@ export class TenantContainerFactory {
 				new SignInManager(apiKeyManager, providers, otpAuthenticator))
 			.addService('membershipValidator', ({ projectSchemaResolver }) =>
 				new MembershipValidator(projectSchemaResolver))
-			.addService('inviteManager', ({ providers, userMailer }) =>
-				new InviteManager(providers, userMailer))
+			.addService('inviteManager', ({ providers, userMailer, projectSchemaResolver }) =>
+				new InviteManager(providers, userMailer, projectSchemaResolver))
 			.addService('otpManager', ({ otpAuthenticator }) =>
 				new OtpManager(otpAuthenticator))
 			.addService('mailTemplateManager', () =>

--- a/packages/schema-utils/src/type-schema/settings.ts
+++ b/packages/schema-utils/src/type-schema/settings.ts
@@ -3,6 +3,9 @@ import { Settings } from '@contember/schema'
 
 export const settingsSchema = Typesafe.partial({
 	useExistsInHasManyFilter: Typesafe.boolean,
+	tenant: Typesafe.partial({
+		inviteExpirationMinutes: Typesafe.integer,
+	}),
 })
 
 const settingSchemaCheck: Typesafe.Equals<Settings.Schema, ReturnType<typeof settingsSchema>> = true

--- a/packages/schema/src/schema/settings.ts
+++ b/packages/schema/src/schema/settings.ts
@@ -1,5 +1,10 @@
 export namespace Settings {
+	export type TenantSettings = {
+		readonly inviteExpirationMinutes?: number
+	}
+
 	export type Schema = {
 		readonly useExistsInHasManyFilter?: boolean
+		readonly tenant?: TenantSettings
 	}
 }


### PR DESCRIPTION
This PR introduces the capability to set a custom expiration period for invitations within a specific project. By updating your project's schema, you can now define the validity of project invitations.

```ts
// api/index.ts
import { createSchema } from '@contember/schema-definition'
import * as model from './model'

export default createSchema(model, it => ({
	...it,
	settings: {
		tenant: { inviteExpirationMinutes: 60 * 48 },
	},
}))

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/472)
<!-- Reviewable:end -->
