### PR TITLE
enforce Non-Null constraints on certain mutation inputs

### DIFF
--- a/packages/engine-content-api/src/schema/mutations/ConnectOrCreateRelationInputProvider.ts
+++ b/packages/engine-content-api/src/schema/mutations/ConnectOrCreateRelationInputProvider.ts
@@ -1,5 +1,5 @@
 import { Accessor, Interface, singletonFactory } from '../../utils'
-import { GraphQLInputObjectType } from 'graphql'
+import { GraphQLInputObjectType, GraphQLNonNull } from 'graphql'
 import { GqlTypeName } from '../utils'
 import { WhereTypeProvider } from '../WhereTypeProvider'
 import { EntityInputProvider, EntityInputType } from './EntityInputProvider'
@@ -43,8 +43,8 @@ export class ConnectOrCreateRelationInputProvider {
 				return new GraphQLInputObjectType({
 					name: GqlTypeName`${entity.name}ConnectOrCreate${relation.name}RelationInput`,
 					fields: () => ({
-						connect: { type: uniqueWhere },
-						create: { type: createInput },
+						connect: { type: new GraphQLNonNull(uniqueWhere) },
+						create: { type: new GraphQLNonNull(createInput) },
 					}),
 				})
 			},

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-acl-allowed.gql
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-acl-allowed.gql
@@ -190,8 +190,8 @@ input RootWithoutRCreateInput {
 }
 
 input OneHasManyEntityConnectOrCreateR2RelationInput {
-  connect: RootUniqueWhere
-  create: RootWithoutRCreateInput
+  connect: RootUniqueWhere!
+  create: RootWithoutRCreateInput!
 }
 
 input OneHasManyEntityUpdateInput {
@@ -216,8 +216,8 @@ input RootWithoutRUpdateInput {
 }
 
 input OneHasManyEntityUpsertR2RelationInput {
-  update: RootWithoutRUpdateInput
-  create: RootWithoutRCreateInput
+  update: RootWithoutRUpdateInput!
+  create: RootWithoutRCreateInput!
 }
 
 type RootConnection {
@@ -248,8 +248,8 @@ input OneHasManyEntityWithoutR2CreateInput {
 }
 
 input RootConnectOrCreateRRelationInput {
-  connect: OneHasManyEntityUniqueWhere
-  create: OneHasManyEntityWithoutR2CreateInput
+  connect: OneHasManyEntityUniqueWhere!
+  create: OneHasManyEntityWithoutR2CreateInput!
 }
 
 input RootUpdateInput {
@@ -269,8 +269,8 @@ input RootUpdateREntityRelationInput {
 }
 
 input RootUpdateRRelationInput {
-  by: OneHasManyEntityUniqueWhere
-  data: OneHasManyEntityWithoutR2UpdateInput
+  by: OneHasManyEntityUniqueWhere!
+  data: OneHasManyEntityWithoutR2UpdateInput!
 }
 
 input OneHasManyEntityWithoutR2UpdateInput {
@@ -279,9 +279,9 @@ input OneHasManyEntityWithoutR2UpdateInput {
 }
 
 input RootUpsertRRelationInput {
-  by: OneHasManyEntityUniqueWhere
-  update: OneHasManyEntityWithoutR2UpdateInput
-  create: OneHasManyEntityWithoutR2CreateInput
+  by: OneHasManyEntityUniqueWhere!
+  update: OneHasManyEntityWithoutR2UpdateInput!
+  create: OneHasManyEntityWithoutR2CreateInput!
 }
 
 type QueryTransaction {

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-acl-restricted-create.gql
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-acl-restricted-create.gql
@@ -206,8 +206,8 @@ input RootUpdateREntityRelationInput {
 }
 
 input RootUpdateRRelationInput {
-  by: OneHasManyEntityUniqueWhere
-  data: OneHasManyEntityWithoutR2UpdateInput
+  by: OneHasManyEntityUniqueWhere!
+  data: OneHasManyEntityWithoutR2UpdateInput!
 }
 
 input OneHasManyEntityWithoutR2UpdateInput {

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-acl-restricted-delete.gql
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-acl-restricted-delete.gql
@@ -185,8 +185,8 @@ input RootWithoutRCreateInput {
 }
 
 input OneHasManyEntityConnectOrCreateR2RelationInput {
-  connect: RootUniqueWhere
-  create: RootWithoutRCreateInput
+  connect: RootUniqueWhere!
+  create: RootWithoutRCreateInput!
 }
 
 input OneHasManyEntityUpdateInput {
@@ -210,8 +210,8 @@ input RootWithoutRUpdateInput {
 }
 
 input OneHasManyEntityUpsertR2RelationInput {
-  update: RootWithoutRUpdateInput
-  create: RootWithoutRCreateInput
+  update: RootWithoutRUpdateInput!
+  create: RootWithoutRCreateInput!
 }
 
 type RootConnection {
@@ -241,8 +241,8 @@ input OneHasManyEntityWithoutR2CreateInput {
 }
 
 input RootConnectOrCreateRRelationInput {
-  connect: OneHasManyEntityUniqueWhere
-  create: OneHasManyEntityWithoutR2CreateInput
+  connect: OneHasManyEntityUniqueWhere!
+  create: OneHasManyEntityWithoutR2CreateInput!
 }
 
 input RootUpdateInput {
@@ -260,8 +260,8 @@ input RootUpdateREntityRelationInput {
 }
 
 input RootUpdateRRelationInput {
-  by: OneHasManyEntityUniqueWhere
-  data: OneHasManyEntityWithoutR2UpdateInput
+  by: OneHasManyEntityUniqueWhere!
+  data: OneHasManyEntityWithoutR2UpdateInput!
 }
 
 input OneHasManyEntityWithoutR2UpdateInput {
@@ -270,9 +270,9 @@ input OneHasManyEntityWithoutR2UpdateInput {
 }
 
 input RootUpsertRRelationInput {
-  by: OneHasManyEntityUniqueWhere
-  update: OneHasManyEntityWithoutR2UpdateInput
-  create: OneHasManyEntityWithoutR2CreateInput
+  by: OneHasManyEntityUniqueWhere!
+  update: OneHasManyEntityWithoutR2UpdateInput!
+  create: OneHasManyEntityWithoutR2CreateInput!
 }
 
 type QueryTransaction {

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-acl-restricted-update.gql
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-acl-restricted-update.gql
@@ -184,8 +184,8 @@ input RootWithoutRCreateInput {
 }
 
 input OneHasManyEntityConnectOrCreateR2RelationInput {
-  connect: RootUniqueWhere
-  create: RootWithoutRCreateInput
+  connect: RootUniqueWhere!
+  create: RootWithoutRCreateInput!
 }
 
 type RootConnection {
@@ -215,8 +215,8 @@ input OneHasManyEntityWithoutR2CreateInput {
 }
 
 input RootConnectOrCreateRRelationInput {
-  connect: OneHasManyEntityUniqueWhere
-  create: OneHasManyEntityWithoutR2CreateInput
+  connect: OneHasManyEntityUniqueWhere!
+  create: OneHasManyEntityWithoutR2CreateInput!
 }
 
 input RootUpdateInput {

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-basic.gql
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-basic.gql
@@ -338,8 +338,8 @@ input PostLocaleWithoutPostCreateInput {
 }
 
 input PostConnectOrCreateLocalesRelationInput {
-  connect: PostLocaleUniqueWhere
-  create: PostLocaleWithoutPostCreateInput
+  connect: PostLocaleUniqueWhere!
+  create: PostLocaleWithoutPostCreateInput!
 }
 
 input PostCreateCategoriesEntityRelationInput {
@@ -359,13 +359,13 @@ input CategoryWithoutPostsCreateInput {
 }
 
 input PostConnectOrCreateCategoriesRelationInput {
-  connect: CategoryUniqueWhere
-  create: CategoryWithoutPostsCreateInput
+  connect: CategoryUniqueWhere!
+  create: CategoryWithoutPostsCreateInput!
 }
 
 input AuthorConnectOrCreatePostsRelationInput {
-  connect: PostUniqueWhere
-  create: PostWithoutAuthorCreateInput
+  connect: PostUniqueWhere!
+  create: PostWithoutAuthorCreateInput!
 }
 
 input AuthorUpdateInput {
@@ -385,8 +385,8 @@ input AuthorUpdatePostsEntityRelationInput {
 }
 
 input AuthorUpdatePostsRelationInput {
-  by: PostUniqueWhere
-  data: PostWithoutAuthorUpdateInput
+  by: PostUniqueWhere!
+  data: PostWithoutAuthorUpdateInput!
 }
 
 input PostWithoutAuthorUpdateInput {
@@ -407,8 +407,8 @@ input PostUpdateLocalesEntityRelationInput {
 }
 
 input PostUpdateLocalesRelationInput {
-  by: PostLocaleUniqueWhere
-  data: PostLocaleWithoutPostUpdateInput
+  by: PostLocaleUniqueWhere!
+  data: PostLocaleWithoutPostUpdateInput!
 }
 
 input PostLocaleWithoutPostUpdateInput {
@@ -417,9 +417,9 @@ input PostLocaleWithoutPostUpdateInput {
 }
 
 input PostUpsertLocalesRelationInput {
-  by: PostLocaleUniqueWhere
-  update: PostLocaleWithoutPostUpdateInput
-  create: PostLocaleWithoutPostCreateInput
+  by: PostLocaleUniqueWhere!
+  update: PostLocaleWithoutPostUpdateInput!
+  create: PostLocaleWithoutPostCreateInput!
 }
 
 input PostUpdateCategoriesEntityRelationInput {
@@ -433,8 +433,8 @@ input PostUpdateCategoriesEntityRelationInput {
 }
 
 input PostUpdateCategoriesRelationInput {
-  by: CategoryUniqueWhere
-  data: CategoryWithoutPostsUpdateInput
+  by: CategoryUniqueWhere!
+  data: CategoryWithoutPostsUpdateInput!
 }
 
 input CategoryWithoutPostsUpdateInput {
@@ -443,15 +443,15 @@ input CategoryWithoutPostsUpdateInput {
 }
 
 input PostUpsertCategoriesRelationInput {
-  by: CategoryUniqueWhere
-  update: CategoryWithoutPostsUpdateInput
-  create: CategoryWithoutPostsCreateInput
+  by: CategoryUniqueWhere!
+  update: CategoryWithoutPostsUpdateInput!
+  create: CategoryWithoutPostsCreateInput!
 }
 
 input AuthorUpsertPostsRelationInput {
-  by: PostUniqueWhere
-  update: PostWithoutAuthorUpdateInput
-  create: PostWithoutAuthorCreateInput
+  by: PostUniqueWhere!
+  update: PostWithoutAuthorUpdateInput!
+  create: PostWithoutAuthorCreateInput!
 }
 
 input CategoryCreateInput {
@@ -486,13 +486,13 @@ input AuthorWithoutPostsCreateInput {
 }
 
 input PostConnectOrCreateAuthorRelationInput {
-  connect: AuthorUniqueWhere
-  create: AuthorWithoutPostsCreateInput
+  connect: AuthorUniqueWhere!
+  create: AuthorWithoutPostsCreateInput!
 }
 
 input CategoryConnectOrCreatePostsRelationInput {
-  connect: PostUniqueWhere
-  create: PostWithoutCategoriesCreateInput
+  connect: PostUniqueWhere!
+  create: PostWithoutCategoriesCreateInput!
 }
 
 input CategoryUpdateInput {
@@ -512,8 +512,8 @@ input CategoryUpdatePostsEntityRelationInput {
 }
 
 input CategoryUpdatePostsRelationInput {
-  by: PostUniqueWhere
-  data: PostWithoutCategoriesUpdateInput
+  by: PostUniqueWhere!
+  data: PostWithoutCategoriesUpdateInput!
 }
 
 input PostWithoutCategoriesUpdateInput {
@@ -539,14 +539,14 @@ input AuthorWithoutPostsUpdateInput {
 }
 
 input PostUpsertAuthorRelationInput {
-  update: AuthorWithoutPostsUpdateInput
-  create: AuthorWithoutPostsCreateInput
+  update: AuthorWithoutPostsUpdateInput!
+  create: AuthorWithoutPostsCreateInput!
 }
 
 input CategoryUpsertPostsRelationInput {
-  by: PostUniqueWhere
-  update: PostWithoutCategoriesUpdateInput
-  create: PostWithoutCategoriesCreateInput
+  by: PostUniqueWhere!
+  update: PostWithoutCategoriesUpdateInput!
+  create: PostWithoutCategoriesCreateInput!
 }
 
 input PostLocaleCreateInput {
@@ -569,8 +569,8 @@ input PostWithoutLocalesCreateInput {
 }
 
 input PostLocaleConnectOrCreatePostRelationInput {
-  connect: PostUniqueWhere
-  create: PostWithoutLocalesCreateInput
+  connect: PostUniqueWhere!
+  create: PostWithoutLocalesCreateInput!
 }
 
 input PostLocaleUpdateInput {
@@ -597,8 +597,8 @@ input PostWithoutLocalesUpdateInput {
 }
 
 input PostLocaleUpsertPostRelationInput {
-  update: PostWithoutLocalesUpdateInput
-  create: PostWithoutLocalesCreateInput
+  update: PostWithoutLocalesUpdateInput!
+  create: PostWithoutLocalesCreateInput!
 }
 
 input PostCreateInput {

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-bug-66.gql
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-bug-66.gql
@@ -241,13 +241,13 @@ input VideoWithoutFrontPageCreateInput {
 }
 
 input FrontPageConnectOrCreateInHouseVideosRelationInput {
-  connect: VideoUniqueWhere
-  create: VideoWithoutFrontPageCreateInput
+  connect: VideoUniqueWhere!
+  create: VideoWithoutFrontPageCreateInput!
 }
 
 input VideoConnectOrCreateFrontPageForIntroRelationInput {
-  connect: FrontPageUniqueWhere
-  create: FrontPageWithoutIntroVideoCreateInput
+  connect: FrontPageUniqueWhere!
+  create: FrontPageWithoutIntroVideoCreateInput!
 }
 
 input VideoCreateFrontPageEntityRelationInput {
@@ -275,13 +275,13 @@ input VideoWithoutFrontPageForIntroCreateInput {
 }
 
 input FrontPageConnectOrCreateIntroVideoRelationInput {
-  connect: VideoUniqueWhere
-  create: VideoWithoutFrontPageForIntroCreateInput
+  connect: VideoUniqueWhere!
+  create: VideoWithoutFrontPageForIntroCreateInput!
 }
 
 input VideoConnectOrCreateFrontPageRelationInput {
-  connect: FrontPageUniqueWhere
-  create: FrontPageWithoutInHouseVideosCreateInput
+  connect: FrontPageUniqueWhere!
+  create: FrontPageWithoutInHouseVideosCreateInput!
 }
 
 input VideoUpdateInput {
@@ -318,8 +318,8 @@ input FrontPageUpdateInHouseVideosEntityRelationInput {
 }
 
 input FrontPageUpdateInHouseVideosRelationInput {
-  by: VideoUniqueWhere
-  data: VideoWithoutFrontPageUpdateInput
+  by: VideoUniqueWhere!
+  data: VideoWithoutFrontPageUpdateInput!
 }
 
 input VideoWithoutFrontPageUpdateInput {
@@ -329,14 +329,14 @@ input VideoWithoutFrontPageUpdateInput {
 }
 
 input FrontPageUpsertInHouseVideosRelationInput {
-  by: VideoUniqueWhere
-  update: VideoWithoutFrontPageUpdateInput
-  create: VideoWithoutFrontPageCreateInput
+  by: VideoUniqueWhere!
+  update: VideoWithoutFrontPageUpdateInput!
+  create: VideoWithoutFrontPageCreateInput!
 }
 
 input VideoUpsertFrontPageForIntroRelationInput {
-  update: FrontPageWithoutIntroVideoUpdateInput
-  create: FrontPageWithoutIntroVideoCreateInput
+  update: FrontPageWithoutIntroVideoUpdateInput!
+  create: FrontPageWithoutIntroVideoCreateInput!
 }
 
 input VideoUpdateFrontPageEntityRelationInput {
@@ -372,13 +372,13 @@ input VideoWithoutFrontPageForIntroUpdateInput {
 }
 
 input FrontPageUpsertIntroVideoRelationInput {
-  update: VideoWithoutFrontPageForIntroUpdateInput
-  create: VideoWithoutFrontPageForIntroCreateInput
+  update: VideoWithoutFrontPageForIntroUpdateInput!
+  create: VideoWithoutFrontPageForIntroCreateInput!
 }
 
 input VideoUpsertFrontPageRelationInput {
-  update: FrontPageWithoutInHouseVideosUpdateInput
-  create: FrontPageWithoutInHouseVideosCreateInput
+  update: FrontPageWithoutInHouseVideosUpdateInput!
+  create: FrontPageWithoutInHouseVideosCreateInput!
 }
 
 type FrontPageConnection {

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-custom-primary.gql
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-custom-primary.gql
@@ -341,8 +341,8 @@ input PostLocaleWithoutPostCreateInput {
 }
 
 input PostConnectOrCreateLocalesRelationInput {
-  connect: PostLocaleUniqueWhere
-  create: PostLocaleWithoutPostCreateInput
+  connect: PostLocaleUniqueWhere!
+  create: PostLocaleWithoutPostCreateInput!
 }
 
 input PostCreateCategoriesEntityRelationInput {
@@ -363,13 +363,13 @@ input CategoryWithoutPostsCreateInput {
 }
 
 input PostConnectOrCreateCategoriesRelationInput {
-  connect: CategoryUniqueWhere
-  create: CategoryWithoutPostsCreateInput
+  connect: CategoryUniqueWhere!
+  create: CategoryWithoutPostsCreateInput!
 }
 
 input AuthorConnectOrCreatePostsRelationInput {
-  connect: PostUniqueWhere
-  create: PostWithoutAuthorCreateInput
+  connect: PostUniqueWhere!
+  create: PostWithoutAuthorCreateInput!
 }
 
 input AuthorUpdateInput {
@@ -389,8 +389,8 @@ input AuthorUpdatePostsEntityRelationInput {
 }
 
 input AuthorUpdatePostsRelationInput {
-  by: PostUniqueWhere
-  data: PostWithoutAuthorUpdateInput
+  by: PostUniqueWhere!
+  data: PostWithoutAuthorUpdateInput!
 }
 
 input PostWithoutAuthorUpdateInput {
@@ -411,8 +411,8 @@ input PostUpdateLocalesEntityRelationInput {
 }
 
 input PostUpdateLocalesRelationInput {
-  by: PostLocaleUniqueWhere
-  data: PostLocaleWithoutPostUpdateInput
+  by: PostLocaleUniqueWhere!
+  data: PostLocaleWithoutPostUpdateInput!
 }
 
 input PostLocaleWithoutPostUpdateInput {
@@ -421,9 +421,9 @@ input PostLocaleWithoutPostUpdateInput {
 }
 
 input PostUpsertLocalesRelationInput {
-  by: PostLocaleUniqueWhere
-  update: PostLocaleWithoutPostUpdateInput
-  create: PostLocaleWithoutPostCreateInput
+  by: PostLocaleUniqueWhere!
+  update: PostLocaleWithoutPostUpdateInput!
+  create: PostLocaleWithoutPostCreateInput!
 }
 
 input PostUpdateCategoriesEntityRelationInput {
@@ -437,8 +437,8 @@ input PostUpdateCategoriesEntityRelationInput {
 }
 
 input PostUpdateCategoriesRelationInput {
-  by: CategoryUniqueWhere
-  data: CategoryWithoutPostsUpdateInput
+  by: CategoryUniqueWhere!
+  data: CategoryWithoutPostsUpdateInput!
 }
 
 input CategoryWithoutPostsUpdateInput {
@@ -447,15 +447,15 @@ input CategoryWithoutPostsUpdateInput {
 }
 
 input PostUpsertCategoriesRelationInput {
-  by: CategoryUniqueWhere
-  update: CategoryWithoutPostsUpdateInput
-  create: CategoryWithoutPostsCreateInput
+  by: CategoryUniqueWhere!
+  update: CategoryWithoutPostsUpdateInput!
+  create: CategoryWithoutPostsCreateInput!
 }
 
 input AuthorUpsertPostsRelationInput {
-  by: PostUniqueWhere
-  update: PostWithoutAuthorUpdateInput
-  create: PostWithoutAuthorCreateInput
+  by: PostUniqueWhere!
+  update: PostWithoutAuthorUpdateInput!
+  create: PostWithoutAuthorCreateInput!
 }
 
 input CategoryCreateInput {
@@ -493,13 +493,13 @@ input AuthorWithoutPostsCreateInput {
 }
 
 input PostConnectOrCreateAuthorRelationInput {
-  connect: AuthorUniqueWhere
-  create: AuthorWithoutPostsCreateInput
+  connect: AuthorUniqueWhere!
+  create: AuthorWithoutPostsCreateInput!
 }
 
 input CategoryConnectOrCreatePostsRelationInput {
-  connect: PostUniqueWhere
-  create: PostWithoutCategoriesCreateInput
+  connect: PostUniqueWhere!
+  create: PostWithoutCategoriesCreateInput!
 }
 
 input CategoryUpdateInput {
@@ -519,8 +519,8 @@ input CategoryUpdatePostsEntityRelationInput {
 }
 
 input CategoryUpdatePostsRelationInput {
-  by: PostUniqueWhere
-  data: PostWithoutCategoriesUpdateInput
+  by: PostUniqueWhere!
+  data: PostWithoutCategoriesUpdateInput!
 }
 
 input PostWithoutCategoriesUpdateInput {
@@ -546,14 +546,14 @@ input AuthorWithoutPostsUpdateInput {
 }
 
 input PostUpsertAuthorRelationInput {
-  update: AuthorWithoutPostsUpdateInput
-  create: AuthorWithoutPostsCreateInput
+  update: AuthorWithoutPostsUpdateInput!
+  create: AuthorWithoutPostsCreateInput!
 }
 
 input CategoryUpsertPostsRelationInput {
-  by: PostUniqueWhere
-  update: PostWithoutCategoriesUpdateInput
-  create: PostWithoutCategoriesCreateInput
+  by: PostUniqueWhere!
+  update: PostWithoutCategoriesUpdateInput!
+  create: PostWithoutCategoriesCreateInput!
 }
 
 input PostLocaleCreateInput {
@@ -578,8 +578,8 @@ input PostWithoutLocalesCreateInput {
 }
 
 input PostLocaleConnectOrCreatePostRelationInput {
-  connect: PostUniqueWhere
-  create: PostWithoutLocalesCreateInput
+  connect: PostUniqueWhere!
+  create: PostWithoutLocalesCreateInput!
 }
 
 input PostLocaleUpdateInput {
@@ -606,8 +606,8 @@ input PostWithoutLocalesUpdateInput {
 }
 
 input PostLocaleUpsertPostRelationInput {
-  update: PostWithoutLocalesUpdateInput
-  create: PostWithoutLocalesCreateInput
+  update: PostWithoutLocalesUpdateInput!
+  create: PostWithoutLocalesCreateInput!
 }
 
 input PostCreateInput {

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-has-many-reduction.gql
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-has-many-reduction.gql
@@ -220,8 +220,8 @@ input PostWithoutLocalesCreateInput {
 }
 
 input PostLocaleConnectOrCreatePostRelationInput {
-  connect: PostUniqueWhere
-  create: PostWithoutLocalesCreateInput
+  connect: PostUniqueWhere!
+  create: PostWithoutLocalesCreateInput!
 }
 
 input PostLocaleUpdateInput {
@@ -247,8 +247,8 @@ input PostWithoutLocalesUpdateInput {
 }
 
 input PostLocaleUpsertPostRelationInput {
-  update: PostWithoutLocalesUpdateInput
-  create: PostWithoutLocalesCreateInput
+  update: PostWithoutLocalesUpdateInput!
+  create: PostWithoutLocalesCreateInput!
 }
 
 type PostConnection {
@@ -280,8 +280,8 @@ input PostLocaleWithoutPostCreateInput {
 }
 
 input PostConnectOrCreateLocalesRelationInput {
-  connect: PostLocaleUniqueWhere
-  create: PostLocaleWithoutPostCreateInput
+  connect: PostLocaleUniqueWhere!
+  create: PostLocaleWithoutPostCreateInput!
 }
 
 input PostUpdateInput {
@@ -301,8 +301,8 @@ input PostUpdateLocalesEntityRelationInput {
 }
 
 input PostUpdateLocalesRelationInput {
-  by: PostLocaleUniqueWhere
-  data: PostLocaleWithoutPostUpdateInput
+  by: PostLocaleUniqueWhere!
+  data: PostLocaleWithoutPostUpdateInput!
 }
 
 input PostLocaleWithoutPostUpdateInput {
@@ -312,9 +312,9 @@ input PostLocaleWithoutPostUpdateInput {
 }
 
 input PostUpsertLocalesRelationInput {
-  by: PostLocaleUniqueWhere
-  update: PostLocaleWithoutPostUpdateInput
-  create: PostLocaleWithoutPostCreateInput
+  by: PostLocaleUniqueWhere!
+  update: PostLocaleWithoutPostUpdateInput!
+  create: PostLocaleWithoutPostCreateInput!
 }
 
 type QueryTransaction {

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-new-builder.gql
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-new-builder.gql
@@ -402,8 +402,8 @@ input CategoryWithoutPostsCreateInput {
 }
 
 input PostConnectOrCreateCategoriesRelationInput {
-  connect: CategoryUniqueWhere
-  create: CategoryWithoutPostsCreateInput
+  connect: CategoryUniqueWhere!
+  create: CategoryWithoutPostsCreateInput!
 }
 
 input PostCreateLocalesEntityRelationInput {
@@ -420,13 +420,13 @@ input PostLocaleWithoutPostCreateInput {
 }
 
 input PostConnectOrCreateLocalesRelationInput {
-  connect: PostLocaleUniqueWhere
-  create: PostLocaleWithoutPostCreateInput
+  connect: PostLocaleUniqueWhere!
+  create: PostLocaleWithoutPostCreateInput!
 }
 
 input AuthorConnectOrCreatePostsRelationInput {
-  connect: PostUniqueWhere
-  create: PostWithoutAuthorCreateInput
+  connect: PostUniqueWhere!
+  create: PostWithoutAuthorCreateInput!
 }
 
 input AuthorUpdateInput {
@@ -446,8 +446,8 @@ input AuthorUpdatePostsEntityRelationInput {
 }
 
 input AuthorUpdatePostsRelationInput {
-  by: PostUniqueWhere
-  data: PostWithoutAuthorUpdateInput
+  by: PostUniqueWhere!
+  data: PostWithoutAuthorUpdateInput!
 }
 
 input PostWithoutAuthorUpdateInput {
@@ -469,8 +469,8 @@ input PostUpdateCategoriesEntityRelationInput {
 }
 
 input PostUpdateCategoriesRelationInput {
-  by: CategoryUniqueWhere
-  data: CategoryWithoutPostsUpdateInput
+  by: CategoryUniqueWhere!
+  data: CategoryWithoutPostsUpdateInput!
 }
 
 input CategoryWithoutPostsUpdateInput {
@@ -479,9 +479,9 @@ input CategoryWithoutPostsUpdateInput {
 }
 
 input PostUpsertCategoriesRelationInput {
-  by: CategoryUniqueWhere
-  update: CategoryWithoutPostsUpdateInput
-  create: CategoryWithoutPostsCreateInput
+  by: CategoryUniqueWhere!
+  update: CategoryWithoutPostsUpdateInput!
+  create: CategoryWithoutPostsCreateInput!
 }
 
 input PostUpdateLocalesEntityRelationInput {
@@ -495,8 +495,8 @@ input PostUpdateLocalesEntityRelationInput {
 }
 
 input PostUpdateLocalesRelationInput {
-  by: PostLocaleUniqueWhere
-  data: PostLocaleWithoutPostUpdateInput
+  by: PostLocaleUniqueWhere!
+  data: PostLocaleWithoutPostUpdateInput!
 }
 
 input PostLocaleWithoutPostUpdateInput {
@@ -506,15 +506,15 @@ input PostLocaleWithoutPostUpdateInput {
 }
 
 input PostUpsertLocalesRelationInput {
-  by: PostLocaleUniqueWhere
-  update: PostLocaleWithoutPostUpdateInput
-  create: PostLocaleWithoutPostCreateInput
+  by: PostLocaleUniqueWhere!
+  update: PostLocaleWithoutPostUpdateInput!
+  create: PostLocaleWithoutPostCreateInput!
 }
 
 input AuthorUpsertPostsRelationInput {
-  by: PostUniqueWhere
-  update: PostWithoutAuthorUpdateInput
-  create: PostWithoutAuthorCreateInput
+  by: PostUniqueWhere!
+  update: PostWithoutAuthorUpdateInput!
+  create: PostWithoutAuthorCreateInput!
 }
 
 input PostCreateInput {
@@ -538,8 +538,8 @@ input AuthorWithoutPostsCreateInput {
 }
 
 input PostConnectOrCreateAuthorRelationInput {
-  connect: AuthorUniqueWhere
-  create: AuthorWithoutPostsCreateInput
+  connect: AuthorUniqueWhere!
+  create: AuthorWithoutPostsCreateInput!
 }
 
 input PostUpdateInput {
@@ -567,8 +567,8 @@ input AuthorWithoutPostsUpdateInput {
 }
 
 input PostUpsertAuthorRelationInput {
-  update: AuthorWithoutPostsUpdateInput
-  create: AuthorWithoutPostsCreateInput
+  update: AuthorWithoutPostsUpdateInput!
+  create: AuthorWithoutPostsCreateInput!
 }
 
 input PostLocaleCreateInput {
@@ -593,8 +593,8 @@ input PostWithoutLocalesCreateInput {
 }
 
 input PostLocaleConnectOrCreatePostRelationInput {
-  connect: PostUniqueWhere
-  create: PostWithoutLocalesCreateInput
+  connect: PostUniqueWhere!
+  create: PostWithoutLocalesCreateInput!
 }
 
 input PostLocaleUpdateInput {
@@ -623,8 +623,8 @@ input PostWithoutLocalesUpdateInput {
 }
 
 input PostLocaleUpsertPostRelationInput {
-  update: PostWithoutLocalesUpdateInput
-  create: PostWithoutLocalesCreateInput
+  update: PostWithoutLocalesUpdateInput!
+  create: PostWithoutLocalesCreateInput!
 }
 
 input CategoryCreateInput {
@@ -649,8 +649,8 @@ input PostWithoutCategoriesCreateInput {
 }
 
 input CategoryConnectOrCreatePostsRelationInput {
-  connect: PostUniqueWhere
-  create: PostWithoutCategoriesCreateInput
+  connect: PostUniqueWhere!
+  create: PostWithoutCategoriesCreateInput!
 }
 
 input CategoryUpdateInput {
@@ -670,8 +670,8 @@ input CategoryUpdatePostsEntityRelationInput {
 }
 
 input CategoryUpdatePostsRelationInput {
-  by: PostUniqueWhere
-  data: PostWithoutCategoriesUpdateInput
+  by: PostUniqueWhere!
+  data: PostWithoutCategoriesUpdateInput!
 }
 
 input PostWithoutCategoriesUpdateInput {
@@ -683,9 +683,9 @@ input PostWithoutCategoriesUpdateInput {
 }
 
 input CategoryUpsertPostsRelationInput {
-  by: PostUniqueWhere
-  update: PostWithoutCategoriesUpdateInput
-  create: PostWithoutCategoriesCreateInput
+  by: PostUniqueWhere!
+  update: PostWithoutCategoriesUpdateInput!
+  create: PostWithoutCategoriesCreateInput!
 }
 
 type QueryTransaction {


### PR DESCRIPTION
This update adds missing non-null constraints to fields in various mutation inputs, including `upsert`, `connectOrCreate`, and `update` within has-many relationships. Previously, the absence of these constraints led to Internal errors. This enhancement ensures the correct GraphQL non-null specifications are in place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/480)
<!-- Reviewable:end -->
