### PR TITLE
feat(tenant-api): add projectSlug to mail template variables

### DIFF
--- a/packages/engine-tenant-api/src/model/mailing/UserMailer.ts
+++ b/packages/engine-tenant-api/src/model/mailing/UserMailer.ts
@@ -11,11 +11,11 @@ export class UserMailer {
 	constructor(
 		private readonly mailer: Mailer,
 		private readonly templateRenderer: TemplateRenderer,
-	) {}
+	) { }
 
 	async sendNewUserInvitedMail(
 		dbContext: DatabaseContext,
-		mailArguments: { email: string; password: string | null; token: string | null; project: string },
+		mailArguments: { email: string; password: string | null; token: string | null; project: string; projectSlug: string },
 		customMailOptions: { projectId: string; variant: string },
 	): Promise<void> {
 		const template = (await this.getCustomTemplate(dbContext, { type: MailType.newUserInvited, ...customMailOptions })) || {
@@ -27,7 +27,7 @@ export class UserMailer {
 
 	async sendExistingUserInvitedEmail(
 		dbContext: DatabaseContext,
-		mailArguments: { email: string; project: string },
+		mailArguments: { email: string; project: string; projectSlug: string },
 		customMailOptions: { projectId: string; variant: string },
 	): Promise<void> {
 		const template = (await this.getCustomTemplate(dbContext, { type: MailType.existingUserInvited, ...customMailOptions })) || {
@@ -39,7 +39,7 @@ export class UserMailer {
 
 	async sendPasswordResetEmail(
 		dbContext: DatabaseContext,
-		mailArguments: { email: string; token: string; project?: string },
+		mailArguments: { email: string; token: string; project?: string; projectSlug?: string },
 		customMailOptions: { projectId?: string; variant: string },
 	): Promise<void> {
 		const template = (await this.getCustomTemplate(dbContext, { type: MailType.passwordReset, ...customMailOptions })) || {

--- a/packages/engine-tenant-api/src/model/service/InviteManager.ts
+++ b/packages/engine-tenant-api/src/model/service/InviteManager.ts
@@ -36,7 +36,7 @@ export class InviteManager {
 		private readonly providers: Providers,
 		private readonly mailer: UserMailer,
 		private readonly projectSchemaResolver: ProjectSchemaResolver,
-	) {}
+	) { }
 
 	async invite(
 		dbContext: DatabaseContext,
@@ -89,11 +89,11 @@ export class InviteManager {
 				if (isNew) {
 					await this.mailer.sendNewUserInvitedMail(
 						trx,
-						{ email, project: project.name, password: generatedPassword, token: resetToken },
+						{ email, project: project.name, projectSlug: project.slug, password: generatedPassword, token: resetToken },
 						customMailOptions,
 					)
 				} else {
-					await this.mailer.sendExistingUserInvitedEmail(trx, { email, project: project.name }, customMailOptions)
+					await this.mailer.sendExistingUserInvitedEmail(trx, { email, project: project.name, projectSlug: project.slug }, customMailOptions)
 				}
 			}
 			return new ResponseOk(new InviteResult(person, isNew))
@@ -110,5 +110,5 @@ export class InviteManager {
 export type InviteResponse = Response<InviteResult, InviteErrorCode>
 
 export class InviteResult {
-	constructor(public readonly person: Omit<PersonRow, 'roles'>, public readonly isNew: boolean) {}
+	constructor(public readonly person: Omit<PersonRow, 'roles'>, public readonly isNew: boolean) { }
 }

--- a/packages/engine-tenant-api/src/model/service/PasswordResetManager.ts
+++ b/packages/engine-tenant-api/src/model/service/PasswordResetManager.ts
@@ -17,7 +17,7 @@ export class PasswordResetManager {
 	constructor(
 		private readonly mailer: UserMailer,
 		private readonly projectManager: ProjectManager,
-	) {}
+	) { }
 
 	public async createPasswordResetRequest(
 		dbContext: DatabaseContext,
@@ -45,6 +45,7 @@ export class PasswordResetManager {
 				email: person.email,
 				token: result.token,
 				project: project?.name,
+				projectSlug: project?.slug,
 			},
 			{
 				variant: mailOptions.mailVariant || '',


### PR DESCRIPTION
So you can use `{{projectSlug}}` in email templates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/481)
<!-- Reviewable:end -->
