### PR TITLE
CLI: skip version check for some commands

### DIFF
--- a/packages/cli-common/src/application/Application.ts
+++ b/packages/cli-common/src/application/Application.ts
@@ -1,9 +1,16 @@
 import { InvalidInputError } from './InputParser'
 import { CommandManager } from './CommandManager'
 import chalk from 'chalk'
+import { Command } from './Command'
 
 export class Application {
-	constructor(private readonly commandManager: CommandManager, private readonly applicationDescription: string) {}
+	constructor(
+		private readonly commandManager: CommandManager,
+		private readonly applicationDescription: string,
+		private readonly options: {
+			beforeRun?: (args: {command: Command<any, any>; name: string; args: string[]}) => void
+		} = {},
+	) {}
 
 	async run(args: string[]): Promise<void> {
 		const [name, ...rest] = args
@@ -70,6 +77,8 @@ export class Application {
 		}
 
 		try {
+			await this.options.beforeRun?.({ command, args, name: fullName })
+
 			const result = await command.run(args)
 			return process.exit(result)
 		} catch (e) {

--- a/packages/cli-common/src/npm/packageManagers/PackageManagerHelpers.ts
+++ b/packages/cli-common/src/npm/packageManagers/PackageManagerHelpers.ts
@@ -12,11 +12,11 @@ export class PackageManagerHelpers {
 		const dirs = await fsManager.listDirectories(dir, workspaces)
 
 		const packageJson = await Promise.all(dirs.map(async it => {
-			const packageJson = await fsManager.tryReadJson<PackageJson>(join(it, 'package.json'))
+			const packageJson = await fsManager.tryReadJson<PackageJson>(join(dir, it, 'package.json'))
 			return packageJson ? [packageJson, it] as const : null
 		}))
 
-		return packageJson.filter(<T>(it: T | null): it is T => it !== null).map(([packageJson, dir]) => new Package(dir, false, packageJson))
+		return packageJson.filter(<T>(it: T | null): it is T => it !== null).map(([packageJson, subDir]) => new Package(join(dir, subDir), false, packageJson))
 	}
 
 	static getWorkspacesFromPackageJson({ packageJson }: { packageJson: PackageJson }): string[] {

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -27,10 +27,6 @@ import { checkVersions } from './utils/checkVersions';
 (async () => {
 	const workspace = await Workspace.get(process.cwd())
 
-	if (!process.env.CONTEMBER_SKIP_VERSION_CHECK) {
-		await checkVersions(workspace)
-	}
-
 	const commands: CommandFactoryList = {
 		['deploy']: () => new DeployCommand(workspace),
 		['version']: () => new VersionCommand(),
@@ -62,7 +58,17 @@ import { checkVersions } from './utils/checkVersions';
 		throw `Node >= 12 is required`
 	}
 	const cliVersion = getPackageVersion()
-	const app = new Application(commandManager, `Contember CLI version ${cliVersion}`)
+	const app = new Application(
+		commandManager,
+		`Contember CLI version ${cliVersion}`,
+		{
+			beforeRun: async ({ name }) => {
+				if (!process.env.CONTEMBER_SKIP_VERSION_CHECK && !['deploy', 'version', 'data:export', 'data:import', 'data:transfer'].includes(name)) {
+					await checkVersions(workspace)
+				}
+			},
+		},
+	)
 	await app.run(process.argv.slice(2))
 })().catch(e => {
 	console.log(e)

--- a/packages/cli/src/utils/checkVersions.ts
+++ b/packages/cli/src/utils/checkVersions.ts
@@ -17,7 +17,7 @@ export const checkVersions = async (workspace: Workspace) => {
 				errors.push(`Package ${packageName} defined in ${jsonPath} is not installed.`)
 				continue
 			}
-			if (!semver.satisfies(pckg.installed.version, pckg.defined.version)) {
+			if (pckg.defined.version !== 'workspace:*' && !semver.satisfies(pckg.installed.version, pckg.defined.version)) {
 				errors.push(`Package ${packageName}@${pckg.installed.version} does not match constraint ${pckg.defined.version} defined in ${jsonPath}.`)
 				continue
 			}


### PR DESCRIPTION
- commands like `deploy` and data transfer related commands does not check version mismatch, allowing to not have node_modules installed
- fix workspace package dirs resolving

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/484)
<!-- Reviewable:end -->
