### PR TITLE
Tenant: allow to configure member view-only ACL

### DIFF
--- a/packages/engine-tenant-api/src/model/authorization/AclSchemaAccessNodeFactory.ts
+++ b/packages/engine-tenant-api/src/model/authorization/AclSchemaAccessNodeFactory.ts
@@ -38,6 +38,12 @@ export class AclSchemaAccessNodeFactory {
 			node.allow(PermissionActions.PROJECT_UPDATE_MEMBER([]), verifier)
 			node.allow(PermissionActions.PROJECT_REMOVE_MEMBER([]), verifier)
 		}
+
+		if (membershipRoles.some(it => it.tenant?.view)) {
+			const verifier = createVerifier(it => it.view ?? {})
+			node.allow(PermissionActions.PROJECT_VIEW_MEMBER([]), verifier)
+		}
+
 		return node
 	}
 }

--- a/packages/engine-tenant-api/tests/cases/unit/authorization/membershipAwareAccessNode.test.ts
+++ b/packages/engine-tenant-api/tests/cases/unit/authorization/membershipAwareAccessNode.test.ts
@@ -68,7 +68,7 @@ const aclSchemaForInviteOnly: Acl.Schema = {
 }
 
 
-test('admin can invite public. cannat manage public, cannot invite lorem', async () => {
+test('admin can invite public. cannot manage public, cannot invite lorem', async () => {
 	const node = new AclSchemaAccessNodeFactory().create(aclSchemaForInviteOnly, [{ role: 'admin', variables: [] }])
 
 	assert.ok(await node.isAllowed(aclEvaluator, PermissionActions.PERSON_INVITE([{ role: 'public', variables: [] }])))
@@ -76,4 +76,28 @@ test('admin can invite public. cannat manage public, cannot invite lorem', async
 	assert.notOk(await node.isAllowed(aclEvaluator, PermissionActions.PERSON_INVITE([{ role: 'lorem', variables: [] }])))
 
 	assert.notOk(await node.isAllowed(aclEvaluator, PermissionActions.PROJECT_REMOVE_MEMBER([{ role: 'public', variables: [] }])))
+})
+
+
+const aclSchemaForViewOnly: Acl.Schema = {
+	roles: {
+		admin: {
+			entities: {},
+			variables: {},
+			tenant: {
+				view: {
+					lorem: true,
+				},
+			},
+		},
+	},
+}
+
+
+test('admin can view lorem, but cannot manage it', async () => {
+	const node = new AclSchemaAccessNodeFactory().create(aclSchemaForViewOnly, [{ role: 'admin', variables: [] }])
+
+	assert.ok(await node.isAllowed(aclEvaluator, PermissionActions.PROJECT_VIEW_MEMBER([{ role: 'lorem', variables: [] }])))
+
+	assert.notOk(await node.isAllowed(aclEvaluator, PermissionActions.PROJECT_REMOVE_MEMBER([{ role: 'lorem', variables: [] }])))
 })

--- a/packages/schema-utils/src/type-schema/acl.ts
+++ b/packages/schema-utils/src/type-schema/acl.ts
@@ -22,6 +22,7 @@ const tenantPermissionsSchema = Typesafe.partial({
 	invite: Typesafe.union(Typesafe.boolean, membershipMatchRuleSchema),
 	unmanagedInvite: Typesafe.union(Typesafe.boolean, membershipMatchRuleSchema),
 	manage: membershipMatchRuleSchema,
+	view: membershipMatchRuleSchema,
 })
 const tenantSchemaCheck: Typesafe.Equals<Acl.TenantPermissions, ReturnType<typeof tenantPermissionsSchema>> = true
 

--- a/packages/schema/src/schema/acl.ts
+++ b/packages/schema/src/schema/acl.ts
@@ -103,6 +103,7 @@ export namespace Acl {
 	export type TenantPermissions = {
 		readonly invite?: boolean | MembershipMatchRule
 		readonly unmanagedInvite?: boolean | MembershipMatchRule
+		readonly view?: MembershipMatchRule
 		readonly manage?: MembershipMatchRule
 	}
 


### PR DESCRIPTION
Now, specific roles can be granted the ability to solely view other members by role. Prior to this update, this functionality required the broader `manage` permission.