### PR TITLE
date field: short response format

### DIFF
--- a/packages/engine-content-api/src/ExecutionContainer.ts
+++ b/packages/engine-content-api/src/ExecutionContainer.ts
@@ -120,7 +120,7 @@ export class ExecutionContainerFactory {
 			.addService('relationFetcher', ({ whereBuilder, orderByBuilder, predicatesInjector, pathFactory }) =>
 				new RelationFetcher(whereBuilder, orderByBuilder, predicatesInjector, pathFactory))
 			.addService('fieldsVisitorFactory', ({ relationFetcher, predicateFactory, whereBuilder, schema }) =>
-				new FieldsVisitorFactory(schema.model, relationFetcher, predicateFactory, whereBuilder))
+				new FieldsVisitorFactory(relationFetcher, predicateFactory))
 			.addService('metaHandler', ({ whereBuilder, predicateFactory }) =>
 				new MetaHandler(whereBuilder, predicateFactory))
 			.addService('uniqueWhereExpander', ({ schema }) =>

--- a/packages/engine-content-api/src/ExecutionContainer.ts
+++ b/packages/engine-content-api/src/ExecutionContainer.ts
@@ -119,8 +119,8 @@ export class ExecutionContainerFactory {
 				new OrderByBuilder(schema.model, joinBuilder))
 			.addService('relationFetcher', ({ whereBuilder, orderByBuilder, predicatesInjector, pathFactory }) =>
 				new RelationFetcher(whereBuilder, orderByBuilder, predicatesInjector, pathFactory))
-			.addService('fieldsVisitorFactory', ({ relationFetcher, predicateFactory, whereBuilder, schema }) =>
-				new FieldsVisitorFactory(relationFetcher, predicateFactory))
+			.addService('fieldsVisitorFactory', ({ relationFetcher, predicateFactory, schema }) =>
+				new FieldsVisitorFactory(relationFetcher, predicateFactory, schema.settings.content ?? {}))
 			.addService('metaHandler', ({ whereBuilder, predicateFactory }) =>
 				new MetaHandler(whereBuilder, predicateFactory))
 			.addService('uniqueWhereExpander', ({ schema }) =>

--- a/packages/engine-content-api/src/ExecutionContainer.ts
+++ b/packages/engine-content-api/src/ExecutionContainer.ts
@@ -107,7 +107,14 @@ export class ExecutionContainerFactory {
 			.addService('whereOptimized', ({ schema }) =>
 				new WhereOptimizer(schema.model, new ConditionOptimizer()))
 			.addService('whereBuilder', ({ joinBuilder, conditionBuilder, pathFactory, whereOptimized, schema }) =>
-				new WhereBuilder(schema.model, joinBuilder, conditionBuilder, pathFactory, whereOptimized, schema.settings.useExistsInHasManyFilter === true))
+				new WhereBuilder(
+					schema.model,
+					joinBuilder,
+					conditionBuilder,
+					pathFactory,
+					whereOptimized,
+					(schema.settings.content?.useExistsInHasManyFilter ?? schema.settings.useExistsInHasManyFilter) === true,
+				))
 			.addService('orderByBuilder', ({ joinBuilder, schema }) =>
 				new OrderByBuilder(schema.model, joinBuilder))
 			.addService('relationFetcher', ({ whereBuilder, orderByBuilder, predicatesInjector, pathFactory }) =>

--- a/packages/engine-content-api/src/mapper/select/handlers/FieldsVisitor.ts
+++ b/packages/engine-content-api/src/mapper/select/handlers/FieldsVisitor.ts
@@ -3,14 +3,11 @@ import { Mapper } from '../../Mapper'
 import { RelationFetcher } from '../RelationFetcher'
 import { SelectExecutionHandlerContext } from '../SelectExecutionHandler'
 import { PredicateFactory } from '../../../acl'
-import { WhereBuilder } from '../WhereBuilder'
 
 export class FieldsVisitor implements Model.RelationByTypeVisitor<void>, Model.ColumnVisitor<void> {
 	constructor(
-		private readonly schema: Model.Schema,
 		private readonly relationFetcher: RelationFetcher,
 		private readonly predicateFactory: PredicateFactory,
-		private readonly whereBuilder: WhereBuilder,
 		private readonly mapper: Mapper,
 		private readonly executionContext: SelectExecutionHandlerContext,
 		private readonly relationPath: Model.AnyRelationContext[],

--- a/packages/engine-content-api/src/mapper/select/handlers/FieldsVisitorFactory.ts
+++ b/packages/engine-content-api/src/mapper/select/handlers/FieldsVisitorFactory.ts
@@ -1,25 +1,19 @@
 import { FieldsVisitor } from './FieldsVisitor'
 import { RelationFetcher } from '../RelationFetcher'
-import { Model } from '@contember/schema'
 import { Mapper } from '../../Mapper'
 import { SelectExecutionHandlerContext } from '../SelectExecutionHandler'
 import { PredicateFactory } from '../../../acl'
-import { WhereBuilder } from '../WhereBuilder'
 
 export class FieldsVisitorFactory {
 	constructor(
-		private readonly schema: Model.Schema,
 		private readonly relationFetcher: RelationFetcher,
 		private readonly predicateFactory: PredicateFactory,
-		private readonly whereBuilder: WhereBuilder,
 	) {}
 
 	create(mapper: Mapper, context: SelectExecutionHandlerContext): FieldsVisitor {
 		return new FieldsVisitor(
-			this.schema,
 			this.relationFetcher,
 			this.predicateFactory,
-			this.whereBuilder,
 			mapper,
 			context,
 			context.relationPath,

--- a/packages/engine-content-api/src/mapper/select/handlers/FieldsVisitorFactory.ts
+++ b/packages/engine-content-api/src/mapper/select/handlers/FieldsVisitorFactory.ts
@@ -3,11 +3,13 @@ import { RelationFetcher } from '../RelationFetcher'
 import { Mapper } from '../../Mapper'
 import { SelectExecutionHandlerContext } from '../SelectExecutionHandler'
 import { PredicateFactory } from '../../../acl'
+import { Settings } from '@contember/schema'
 
 export class FieldsVisitorFactory {
 	constructor(
 		private readonly relationFetcher: RelationFetcher,
 		private readonly predicateFactory: PredicateFactory,
+		private readonly settings: Settings.ContentSettings,
 	) {}
 
 	create(mapper: Mapper, context: SelectExecutionHandlerContext): FieldsVisitor {
@@ -17,6 +19,7 @@ export class FieldsVisitorFactory {
 			mapper,
 			context,
 			context.relationPath,
+			this.settings,
 		)
 	}
 }

--- a/packages/schema-definition/src/presets.ts
+++ b/packages/schema-definition/src/presets.ts
@@ -7,6 +7,18 @@ const v1_3preset: Settings.Schema = {
 	},
 }
 
+
+const v1_4preset: Settings.Schema = {
+	tenant: {
+		inviteExpirationMinutes: 60 * 24 * 7, // 7 days
+	},
+	content: {
+		shortDateResponse: true,
+		useExistsInHasManyFilter: true,
+	},
+}
+
 export const settingsPresets = {
 	'v1.3': v1_3preset,
+	'v1.4': v1_4preset,
 }

--- a/packages/schema-definition/src/presets.ts
+++ b/packages/schema-definition/src/presets.ts
@@ -6,6 +6,7 @@ const v1_3preset: Settings.Schema = {
 		inviteExpirationMinutes: 60 * 24 * 7, // 7 days
 	},
 }
+
 export const settingsPresets = {
 	'v1.3': v1_3preset,
 }

--- a/packages/schema-utils/src/type-schema/settings.ts
+++ b/packages/schema-utils/src/type-schema/settings.ts
@@ -3,8 +3,12 @@ import { Settings } from '@contember/schema'
 
 export const settingsSchema = Typesafe.partial({
 	useExistsInHasManyFilter: Typesafe.boolean,
+
 	tenant: Typesafe.partial({
 		inviteExpirationMinutes: Typesafe.integer,
+	}),
+	content: Typesafe.partial({
+		useExistsInHasManyFilter: Typesafe.boolean,
 	}),
 })
 

--- a/packages/schema-utils/src/type-schema/settings.ts
+++ b/packages/schema-utils/src/type-schema/settings.ts
@@ -9,6 +9,7 @@ export const settingsSchema = Typesafe.partial({
 	}),
 	content: Typesafe.partial({
 		useExistsInHasManyFilter: Typesafe.boolean,
+		shortDateResponse: Typesafe.boolean,
 	}),
 })
 

--- a/packages/schema/src/schema/settings.ts
+++ b/packages/schema/src/schema/settings.ts
@@ -3,8 +3,17 @@ export namespace Settings {
 		readonly inviteExpirationMinutes?: number
 	}
 
-	export type Schema = {
+	export type ContentSettings = {
 		readonly useExistsInHasManyFilter?: boolean
+	}
+
+	export type Schema = {
 		readonly tenant?: TenantSettings
+		readonly content?: ContentSettings
+
+		/**
+		 * @deprecated
+		 */
+		readonly useExistsInHasManyFilter?: boolean
 	}
 }

--- a/packages/schema/src/schema/settings.ts
+++ b/packages/schema/src/schema/settings.ts
@@ -4,6 +4,7 @@ export namespace Settings {
 	}
 
 	export type ContentSettings = {
+		readonly shortDateResponse?: boolean
 		readonly useExistsInHasManyFilter?: boolean
 	}
 


### PR DESCRIPTION
Even if you use just a "date" format, the engine will respond with a iso datetime string. it is because node-pg automatically converts the date into `Date` object, which is later converted into a iso-string.

Now, you can set `content.shortDateResponse` to `true` to enable short response format.

Also, it will be a in default preset for 1.4.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/488)
<!-- Reviewable:end -->
