### PR TITLE
schema definition strict mode

### DIFF
--- a/packages/schema-definition/src/createSchema.ts
+++ b/packages/schema-definition/src/createSchema.ts
@@ -4,12 +4,23 @@ import * as AclDefinition from './acl/definition'
 import * as ActionsDefinition from './actions/definition'
 import { Schema } from '@contember/schema'
 import { emptySchema } from '@contember/schema-utils'
+import { allStrict, StrictOptions, StrictDefinitionValidator } from './strict'
 
-export const createSchema = (definitions: Record<string, any>, modifyCallback?: (schema: Schema) => Schema): Schema => {
-	const model = SchemaDefinition.createModel(definitions)
+export const createSchema = (definitions: Record<string, any>, modifyCallback?: (schema: Schema) => Schema, options?: {
+	strict?: boolean | StrictOptions
+}): Schema => {
+	const strictOptions = options?.strict === true ? allStrict : (options?.strict || {})
+	const strictDefinitionValidator = new StrictDefinitionValidator(strictOptions)
+
+	const model = SchemaDefinition.createModel(definitions, { strictDefinitionValidator: strictDefinitionValidator })
 	const validation = InputValidation.parseDefinition(definitions)
 	const acl = AclDefinition.createAcl(definitions, model)
 	const actions = ActionsDefinition.createActions(definitions)
 	const schema = { ...emptySchema, model, validation, acl, actions }
+
+	if (strictDefinitionValidator.warnings.length > 0) {
+		throw `Strict schema validation failed: \n${strictDefinitionValidator.warnings.map(it => `- ${it.message}`).join('\n')}`
+	}
+
 	return modifyCallback ? modifyCallback(schema) : schema
 }

--- a/packages/schema-definition/src/model/definition/context.ts
+++ b/packages/schema-definition/src/model/definition/context.ts
@@ -1,0 +1,10 @@
+import { EntityRegistry, EnumRegistry } from './internal'
+import { StrictDefinitionValidator } from '../../strict'
+import { NamingConventions } from '@contember/schema-utils'
+
+export type CommonContext = {
+	conventions: NamingConventions
+	enumRegistry: EnumRegistry
+	entityRegistry: EntityRegistry
+	strictDefinitionValidator: StrictDefinitionValidator
+}

--- a/packages/schema-definition/src/model/definition/extensions.ts
+++ b/packages/schema-definition/src/model/definition/extensions.ts
@@ -1,19 +1,17 @@
 import { Model } from '@contember/schema'
 import { EntityConstructor, FieldsDefinition } from './types'
-import { EntityRegistry, EnumRegistry } from './internal'
-import { NamingConventions } from '@contember/schema-utils'
+import { EntityRegistry } from './internal'
 import { createMetadataStore, DecoratorFunction } from '../../utils'
+import { CommonContext } from './context'
 
-interface EntityExtensionArgs {
-	entity: Model.Entity
-	definition: FieldsDefinition
-	conventions: NamingConventions
-	enumRegistry: EnumRegistry
-	entityRegistry: EntityRegistry
-
-	/** @deprecated use entityRegistry */
-	registry: EntityRegistry
-}
+export type EntityExtensionArgs =
+	& {
+		entity: Model.Entity
+		definition: FieldsDefinition
+		/** @deprecated use entityRegistry */
+		registry: EntityRegistry
+	}
+	& CommonContext
 
 const entityExtensionsStore = createMetadataStore<EntityExtension[]>([])
 

--- a/packages/schema-definition/src/model/definition/fieldDefinitions/FieldDefinition.ts
+++ b/packages/schema-definition/src/model/definition/fieldDefinitions/FieldDefinition.ts
@@ -1,6 +1,5 @@
 import { Model } from '@contember/schema'
-import { NamingConventions } from '@contember/schema-utils'
-import { EntityRegistry, EnumRegistry } from '../internal'
+import { CommonContext } from '../context'
 
 export abstract class FieldDefinition<O> {
 	constructor(public readonly options: O) {}
@@ -12,11 +11,11 @@ export abstract class FieldDefinition<O> {
 	abstract createField(context: CreateFieldContext): Model.AnyField
 }
 
-export interface CreateFieldContext {
-	name: string
-	entityName: string
-	conventions: NamingConventions
-	enumRegistry: EnumRegistry
-	entityRegistry: EntityRegistry
-}
+export type CreateFieldContext =
+	&  {
+		name: string
+		entityName: string
+	}
+	& CommonContext
+
 export type Map = { [name: string]: FieldDefinition<any> }

--- a/packages/schema-definition/src/model/definition/fieldDefinitions/ManyHasManyDefinition.ts
+++ b/packages/schema-definition/src/model/definition/fieldDefinitions/ManyHasManyDefinition.ts
@@ -21,7 +21,7 @@ export class ManyHasManyDefinitionImpl extends FieldDefinition<ManyHasManyDefini
 		return this.withOption('orderBy', [...(this.options.orderBy || []), { path, direction: direction as Model.OrderDirection }])
 	}
 
-	createField({ name, conventions, entityName, entityRegistry }: CreateFieldContext): Model.AnyField {
+	createField({ name, conventions, entityName, entityRegistry, strictDefinitionValidator }: CreateFieldContext): Model.AnyField {
 		const options = this.options
 		const columnNames = conventions.getJoiningTableColumnNames(
 			entityName,
@@ -36,6 +36,8 @@ export class ManyHasManyDefinitionImpl extends FieldDefinition<ManyHasManyDefini
 			eventLog: { enabled: true },
 			...options.joiningTable,
 		}
+
+		strictDefinitionValidator.validateInverseSide(entityName, name, options)
 
 		return {
 			type: Model.RelationType.ManyHasMany,

--- a/packages/schema-definition/src/model/definition/fieldDefinitions/OneHasOneDefinition.ts
+++ b/packages/schema-definition/src/model/definition/fieldDefinitions/OneHasOneDefinition.ts
@@ -25,6 +25,10 @@ export class OneHasOneDefinitionImpl extends FieldDefinition<OneHasOneDefinition
 		return this.withOption('joiningColumn', { ...this.options.joiningColumn, onDelete: Model.OnDelete.setNull })
 	}
 
+	restrictOnDelete(): Interface<OneHasOneDefinition> {
+		return this.withOption('joiningColumn', { ...this.options.joiningColumn, onDelete: Model.OnDelete.restrict })
+	}
+
 	notNull(): Interface<OneHasOneDefinition> {
 		return this.withOption('nullable', false)
 	}
@@ -33,9 +37,12 @@ export class OneHasOneDefinitionImpl extends FieldDefinition<OneHasOneDefinition
 		return this.withOption('orphanRemoval', true)
 	}
 
-	createField({ name, conventions, entityRegistry }: CreateFieldContext): Model.AnyField {
+	createField({ name, conventions, entityRegistry, strictDefinitionValidator, entityName }: CreateFieldContext): Model.AnyField {
 		const options = this.options
 		const joiningColumn: Partial<Model.JoiningColumn> = options.joiningColumn || {}
+
+		strictDefinitionValidator.validateInverseSide(entityName, name, options)
+		strictDefinitionValidator.validateOnCascade(entityName, name, joiningColumn)
 
 		return {
 			name: name,

--- a/packages/schema-definition/src/model/definition/index.ts
+++ b/packages/schema-definition/src/model/definition/index.ts
@@ -6,6 +6,7 @@ import 'reflect-metadata'
 import { FieldDefinition } from './fieldDefinitions'
 import { isEntityConstructor } from '../../utils'
 import { DefaultNamingConventions } from '@contember/schema-utils'
+import { StrictOptions, StrictDefinitionValidator } from '../../strict'
 
 export * from './fieldDefinitions'
 export * from './EventLogDefinition'
@@ -24,8 +25,13 @@ export type ModelDefinition<M> = {
 	[K in keyof M]: unknown
 }
 
-export function createModel<M extends ModelDefinition<M>>(definitions: M): Model.Schema {
-	const schemaBuilder = new SchemaBuilder(new DefaultNamingConventions())
+export function createModel<M extends ModelDefinition<M>>(definitions: M, options: {
+	strictDefinitionValidator?: StrictDefinitionValidator
+} = {}): Model.Schema {
+	const schemaBuilder = new SchemaBuilder(
+		new DefaultNamingConventions(),
+		options.strictDefinitionValidator,
+	)
 	for (const [name, definition] of Object.entries(definitions)) {
 		if (definition instanceof EnumDefinition) {
 			schemaBuilder.addEnum(name, definition)

--- a/packages/schema-definition/src/model/definition/internal/SchemaBuilder.ts
+++ b/packages/schema-definition/src/model/definition/internal/SchemaBuilder.ts
@@ -8,13 +8,17 @@ import { EntityRegistry } from './EntityRegistry'
 import { EnumRegistry } from './EnumRegistry'
 import { ColumnDefinition } from '../fieldDefinitions'
 import { applyEntityExtensions } from '../extensions'
+import { StrictOptions, StrictDefinitionValidator } from '../../../strict'
 
 export class SchemaBuilder {
 	private entityRegistry = new EntityRegistry()
 
 	private enumRegistry = new EnumRegistry()
 
-	constructor(private readonly conventions: NamingConventions) {}
+	constructor(
+		private readonly conventions: NamingConventions,
+		private readonly strictDefinitionValidator: StrictDefinitionValidator = new StrictDefinitionValidator({}),
+	) {}
 
 	public addEntity(name: string, entity: EntityConstructor): void {
 		this.entityRegistry.register(name, entity)
@@ -47,6 +51,7 @@ export class SchemaBuilder {
 							conventions: this.conventions,
 							enumRegistry: this.enumRegistry,
 							entityRegistry: this.entityRegistry,
+							strictDefinitionValidator: this.strictDefinitionValidator,
 						})
 					})
 					.reduce<Model.Entity['fields']>((acc, field) => {
@@ -67,6 +72,7 @@ export class SchemaBuilder {
 				entityRegistry: this.entityRegistry,
 				conventions: this.conventions,
 				enumRegistry: this.enumRegistry,
+				strictDefinitionValidator: this.strictDefinitionValidator,
 			})
 		})
 

--- a/packages/schema-definition/src/strict.ts
+++ b/packages/schema-definition/src/strict.ts
@@ -1,0 +1,40 @@
+import { Model } from '@contember/schema'
+
+export type StrictOptions = {
+	requireOnDelete?: boolean
+	requireInverseSide?: boolean
+}
+
+export const allStrict: StrictOptions = {
+	requireOnDelete: true,
+	requireInverseSide: true,
+}
+
+
+export type Warning = { message: string }
+
+export class StrictDefinitionValidator {
+	public readonly warnings: Warning[] = []
+
+	constructor(
+		private readonly options: StrictOptions,
+	) {
+	}
+
+	public validateInverseSide(entityName: string, field: string, definition: { inversedBy?: string }): void {
+		if (!definition.inversedBy && this.options.requireInverseSide) {
+			this.registerWarning(`${entityName}.${field}: inverse side of the relation is not defined.`)
+		}
+	}
+
+
+	public validateOnCascade(entityName: string, field: string, definition: { onDelete?: Model.OnDelete}): void {
+		if (!definition.onDelete && this.options.requireOnDelete) {
+			this.registerWarning(`${entityName}.${field}: onDelete behaviour is not set. Use one of cascadeOnDelete(), setNullOnDelete() or restrictOnDelete().`)
+		}
+	}
+
+	public registerWarning(message: string): void {
+		this.warnings.push({ message })
+	}
+}

--- a/packages/schema-definition/tests/cases/unit/createSchema.test.ts
+++ b/packages/schema-definition/tests/cases/unit/createSchema.test.ts
@@ -97,3 +97,26 @@ test('basic createSchema test', () => {
 		}
 	`)
 })
+
+
+namespace StrictModel {
+	export class Genre {
+		name = c.stringColumn()
+
+	}
+	export class Book {
+		title = c.stringColumn()
+		genre = c.manyHasOne(Genre)
+	}
+}
+
+test('strict test', () => {
+	const cb = () => createSchema(StrictModel, schema => ({
+		...schema,
+		settings: settingsPresets['v1.3'],
+	}), { strict: true })
+
+	expect(cb).toThrow(`Strict schema validation failed: 
+- Book.genre: inverse side of the relation is not defined.
+- Book.genre: onDelete behaviour is not set. Use one of cascadeOnDelete(), setNullOnDelete() or restrictOnDelete().`)
+})

--- a/packages/schema-definition/tests/cases/unit/extendEntity.test.ts
+++ b/packages/schema-definition/tests/cases/unit/extendEntity.test.ts
@@ -10,16 +10,14 @@ namespace ExtendedModel {
 	}
 
 	const addField = (name: string, field: FieldDefinition<any>): DecoratorFunction<any> => {
-		return extendEntity(({ entity, conventions, entityRegistry, enumRegistry }) => ({
+		return extendEntity(({ entity, ...context }) => ({
 			...entity,
 			fields: {
 				...entity.fields,
 				[name]: field.createField({
 					name,
-					enumRegistry,
-					entityRegistry,
-					conventions,
 					entityName: entity.name,
+					...context,
 				}),
 			},
 		}))


### PR DESCRIPTION
fixes #394

`createSchema` accepts `strict` option, which enables additional checks in the schema defintion, currently you may enable to require inverse side and explicit onDelete behaviour


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/490)
<!-- Reviewable:end -->
