### PR TITLE
fix removing unique constraint

### DIFF
--- a/packages/engine-system-api/src/migrations/2023-10-19-173000-fix-unique.ts
+++ b/packages/engine-system-api/src/migrations/2023-10-19-173000-fix-unique.ts
@@ -1,0 +1,49 @@
+import { MigrationArgs, MigrationBuilder } from '@contember/database-migrations'
+import { wrapIdentifier } from '@contember/database'
+import { SystemMigrationArgs } from './types'
+import { acceptEveryFieldVisitor, SchemaDatabaseMetadata } from '@contember/schema-utils'
+import { getUniqueConstraintColumns } from '@contember/schema-migrations'
+
+export default async function (builder: MigrationBuilder, args: MigrationArgs<SystemMigrationArgs>) {
+	const schema = await args.schemaResolver(args.connection)
+	const stages = (await args.connection.query<{schema: string}>('SELECT schema FROM stage')).rows
+	const metadataByStage: Record<string, SchemaDatabaseMetadata> = {}
+
+	for (const entity of Object.values(schema.model.entities)) {
+		if (entity.view) {
+			continue
+		}
+
+		const expectedUnique: string[][] = []
+
+		for (const uniq of entity.unique) {
+			const columns = getUniqueConstraintColumns({
+				entity,
+				fields: uniq.fields,
+				model: schema.model,
+			})
+			expectedUnique.push(columns)
+		}
+
+
+		for (const stage of stages) {
+			const databaseMetadata = metadataByStage[stage.schema] ??= await args.databaseMetadataResolver(args.connection, stage.schema)
+
+			const existingUniqueConstraints = databaseMetadata.getAllUniqueConstraints().filter(it => it.tableName === entity.tableName)
+			for (const constraint of existingUniqueConstraints) {
+				if (constraint.columnNames.length === 1 || expectedUnique.some(it => stringArrayEquals(it, constraint.columnNames))) {
+					continue
+				}
+				builder.sql(`ALTER TABLE ${wrapIdentifier(stage.schema)}.${wrapIdentifier(entity.tableName)} DROP CONSTRAINT ${wrapIdentifier(constraint.constraintName)}`)
+			}
+		}
+	}
+}
+const stringArrayEquals = (colA: string[], colB: string[]) => {
+	if (colA.length !== colB.length) {
+		return false
+	}
+	const a = [...colA].sort()
+	const b = [...colB].sort()
+	return a.every((it, index) => it === b[index])
+}

--- a/packages/engine-system-api/src/migrations/runner.ts
+++ b/packages/engine-system-api/src/migrations/runner.ts
@@ -18,6 +18,7 @@ import _20220208140500dropdeadcode from './2022-02-08-140500-drop-deadcode'
 import _20220208144400dynamicstageschema from './2022-02-08-144400-dynamic-stage-schema'
 import _20221003110000tableondelete from './2022-10-03-110000-table-on-delete'
 import _20230911174000fixondelete from './2023-09-11-174000-fix-on-delete'
+import _20231019173000fixunique from './2023-10-19-173000-fix-unique'
 import snapshot from './snapshot'
 
 import { Client, Connection, createDatabaseIfNotExists, DatabaseConfig } from '@contember/database'
@@ -48,6 +49,7 @@ const migrations = {
 	'2022-02-08-144400-dynamic-stage-schema': _20220208144400dynamicstageschema,
 	'2022-10-03-110000-table-on-delete': _20221003110000tableondelete,
 	'2023-09-11-174000-fix-on-delete': _20230911174000fixondelete,
+	'2023-10-19-173000-fix-unique': _20231019173000fixunique,
 }
 
 

--- a/packages/engine-system-api/src/model/metadata/ResolvedDatabaseMetadata.ts
+++ b/packages/engine-system-api/src/model/metadata/ResolvedDatabaseMetadata.ts
@@ -25,6 +25,10 @@ export class ResolvedDatabaseMetadata implements SchemaDatabaseMetadata {
 	) {
 	}
 
+	getAllUniqueConstraints(): UniqueConstraintMetadata[] {
+		return this.uniqueConstraints
+	}
+
 	getUniqueConstraint(tableName: string, constraintName: string): UniqueConstraintMetadata | null {
 		return this.uniqueConstraints.find(it => it.tableName === tableName && it.constraintName === constraintName) ?? null
 	}

--- a/packages/engine-system-api/src/model/metadata/ResolvedDatabaseMetadata.ts
+++ b/packages/engine-system-api/src/model/metadata/ResolvedDatabaseMetadata.ts
@@ -9,8 +9,12 @@ import {
 } from '@contember/schema-utils'
 
 const stringArrayEquals = (colA: string[], colB: string[]) => {
-	return colA.length === colB.length
-		&& colA.every((it, index) => it === colB[index])
+	if (colA.length !== colB.length) {
+		return false
+	}
+	const a = [...colA].sort()
+	const b = [...colB].sort()
+	return a.every((it, index) => it === b[index])
 }
 
 export class ResolvedDatabaseMetadata implements SchemaDatabaseMetadata {

--- a/packages/engine-system-api/tests/cases/migrations/2023-10-19-173000-fix-unique.test.ts
+++ b/packages/engine-system-api/tests/cases/migrations/2023-10-19-173000-fix-unique.test.ts
@@ -1,0 +1,66 @@
+import migration from '../../../src/migrations/2023-10-19-173000-fix-unique'
+import { createMigrationBuilder } from '@contember/database-migrations'
+import { assert, test } from 'vitest'
+import { c, createSchema } from '@contember/schema-definition'
+import { dummySchemaDatabaseMetadata } from '@contember/schema-utils'
+import { createConnectionMock } from '@contember/database-tester'
+
+namespace UniqueModel {
+
+	@c.Unique('colA', 'colB')
+	@c.Unique('manyHasOneBar', 'colB')
+	export class Foo {
+		hasOneBar = c.oneHasOne(Bar)
+		manyHasOneBar = c.manyHasOne(Bar)
+		singleColUnique = c.stringColumn().unique()
+
+		colA = c.stringColumn()
+		colB = c.stringColumn()
+		colC = c.stringColumn()
+	}
+
+	export class Bar {
+
+	}
+}
+
+test('unique fix test', async () => {
+	const builder = createMigrationBuilder()
+	const connection = createConnectionMock([{
+		sql: 'select schema from stage',
+		response: { rows: [{ schema: 'stage_live' }] },
+	}])
+	await migration(builder, {
+		connection: connection,
+		databaseMetadataResolver: () => Promise.resolve({
+			...dummySchemaDatabaseMetadata,
+			getAllUniqueConstraints: () => [
+				{ constraintName: 'valid1', tableName: 'foo', columnNames: ['col_a', 'col_b'] },
+				{ constraintName: 'valid2', tableName: 'foo', columnNames: ['col_b', 'many_has_one_bar_id'] },
+				{ constraintName: 'valid3', tableName: 'foo', columnNames: ['single_col_unique'] },
+				{ constraintName: 'valid4', tableName: 'foo', columnNames: ['has_one_bar_id'] },
+
+				{ constraintName: 'invalid1', tableName: 'foo', columnNames: ['col_a', 'col_c'] },
+				{ constraintName: 'invalid2', tableName: 'foo', columnNames: ['col_c', 'many_has_one_bar_id'] },
+
+			],
+		}),
+		schemaResolver: () => Promise.resolve(createSchema(UniqueModel)),
+		project: {
+			slug: 'test',
+			stages: [
+				{
+					slug: 'prod',
+					name: 'prod',
+				},
+			],
+		},
+	})
+	assert.equal(
+		builder.getSql(),
+		`ALTER TABLE "stage_live"."foo" DROP CONSTRAINT "invalid1";
+ALTER TABLE "stage_live"."foo" DROP CONSTRAINT "invalid2";
+`,
+	)
+})
+

--- a/packages/schema-migrations/src/modifications/constraints/index.ts
+++ b/packages/schema-migrations/src/modifications/constraints/index.ts
@@ -1,2 +1,3 @@
 export * from './CreateUniqueConstraintModification'
 export * from './RemoveUniqueConstraintModification'
+export * from './utils'

--- a/packages/schema-utils/src/SchemaDatabaseMetadata.ts
+++ b/packages/schema-utils/src/SchemaDatabaseMetadata.ts
@@ -45,6 +45,8 @@ export enum ForeignKeyDeleteAction {
 }
 
 export interface SchemaDatabaseMetadata {
+	getAllUniqueConstraints(): UniqueConstraintMetadata[]
+
 	getUniqueConstraint(tableName: string, constraintName: string): UniqueConstraintMetadata | null
 
 	getForeignKeyConstraint(tableName: string, constraintName: string): ForeignKeyConstraintMetadata | null
@@ -58,6 +60,9 @@ export interface SchemaDatabaseMetadata {
 
 
 export const dummySchemaDatabaseMetadata: SchemaDatabaseMetadata = {
+	getAllUniqueConstraints(): UniqueConstraintMetadata[] {
+		return []
+	},
 	getForeignKeyConstraint(): ForeignKeyConstraintMetadata | null {
 		return null
 	}, getUniqueConstraint(): UniqueConstraintMetadata | null {


### PR DESCRIPTION
This PR fixes an issue where composed unique constraints weren't removed from the database due to column order mismatches in the schema and in the database.

Changes include:
1. **Column Sorting for Constraints:** Columns are now sorted before operations to prevent mismatches and ensure accurate constraint modifications.

2. **Cleanup Migration:** A migration script is added to identify and remove lingering unique constraints caused by past order discrepancies.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/499)
<!-- Reviewable:end -->
