### PR TITLE
fix: support interface fragments in graphql ast factory

### DIFF
--- a/packages/engine-content-api/src/resolvers/GraphQlQueryAstFactory.ts
+++ b/packages/engine-content-api/src/resolvers/GraphQlQueryAstFactory.ts
@@ -3,9 +3,11 @@ import {
 	FieldNode as GraphQlFieldNode,
 	FragmentSpreadNode,
 	getArgumentValues,
+	GraphQLInterfaceType,
 	GraphQLObjectType,
 	GraphQLOutputType,
 	GraphQLResolveInfo,
+	isInterfaceType,
 	isListType,
 	isNonNullType,
 	isObjectType,
@@ -29,7 +31,7 @@ export class GraphQlQueryAstFactory {
 
 	private createFromNode(
 		info: GraphQLResolveInfo,
-		parentType: GraphQLObjectType,
+		parentType: GraphQLObjectType | GraphQLInterfaceType,
 		node: GraphQlFieldNode,
 		path: string[],
 		filter: NodeFilter,
@@ -60,7 +62,7 @@ export class GraphQlQueryAstFactory {
 
 	private processSelectionSet(
 		info: GraphQLResolveInfo,
-		parentType: GraphQLObjectType,
+		parentType: GraphQLObjectType | GraphQLInterfaceType,
 		selectionSet: SelectionSetNode,
 		path: string[],
 		filter: NodeFilter,
@@ -80,12 +82,12 @@ export class GraphQlQueryAstFactory {
 				}
 				const typeName = fragmentDefinition.typeCondition.name.value
 				const subField = info.schema.getType(typeName)
-				if (!isObjectType(subField)) {
-					throw new Error('GraphQlQueryAstFactory: subfield is expected to be GraphQLObjectType')
+				if (!isObjectType(subField) && !isInterfaceType(subField)) {
+					throw new Error('GraphQlQueryAstFactory: subfield is expected to be GraphQLObjectType or GraphQLInterfaceType')
 				}
 				const fragmentSelection = this.processSelectionSet(
 					info,
-					subField as GraphQLObjectType,
+					subField,
 					fragmentDefinition.selectionSet,
 					path,
 					filter,


### PR DESCRIPTION
now, this failed:

```graphql
fragment MutationResult on MutationResult {
 #...
}
mutation {
	transaction {
		createTag(data: {
			name: "xxx"
		}) {
			... MutationResult
# ...
```

because MutationResult is an interface

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/508)
<!-- Reviewable:end -->
