### PR TITLE
fix(tenant-api): fix email validation upon profile change

### DIFF
--- a/packages/engine-tenant-api/src/model/service/PersonManager.ts
+++ b/packages/engine-tenant-api/src/model/service/PersonManager.ts
@@ -18,7 +18,7 @@ class PersonManager {
 	}
 
 	async changeMyProfile(dbContext: DatabaseContext, person: PersonRow, data: ChangeProfileData): Promise<PersonManager.ProfileChangeResponse> {
-		if (data.email !== undefined) {
+		if (data.email !== undefined && person.email !== data.email) {
 			const validationError = await this.emailValidator.validateEmail(dbContext, data.email)
 			if (validationError !== null) {
 				return new ResponseError(validationError.error, validationError.errorMessage)


### PR DESCRIPTION
Attempting to execute the `changeMyProfile` mutation with an email that matches the one already associated with the user results in a validation error.

The existing code in `EmailValidator` currently verifies if the email is already in use, triggering an error in such scenarios.

This modification ensures that the mutation becomes idempotent.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/510)
<!-- Reviewable:end -->
