### PR TITLE
http improvements: add /health endpoint, allow to suppress access log

### DIFF
--- a/packages/engine-http/src/MasterContainer.ts
+++ b/packages/engine-http/src/MasterContainer.ts
@@ -34,6 +34,7 @@ import { homepageController, playgroundController } from './misc'
 import { Plugin } from './plugin/Plugin'
 import { Application } from './application/application'
 import { ApplicationWorkerManager } from './workers/ApplicationWorkerManager'
+import { HttpResponse } from './common'
 
 export interface MasterContainer {
 	initializer: Initializer
@@ -160,6 +161,10 @@ export class MasterContainerFactory {
 				it.addRoute('transfer', '/export', exportApiMiddlewareFactory.create())
 				it.addRoute('misc', '/playground', playgroundController)
 				it.addRoute('misc', '/', homepageController)
+
+				it.addInternalRoute('internal', '/health', () => {
+					return new HttpResponse(200, 'OK')
+				})
 			})
 			.addService('initializer', ({ projectGroupContainer }) =>
 				new Initializer(projectGroupContainer))

--- a/packages/engine-http/src/config/configSchema.ts
+++ b/packages/engine-http/src/config/configSchema.ts
@@ -87,6 +87,21 @@ export const serverConfigSchema = Typesafe.object({
 	port: Typesafe.number,
 	http: Typesafe.partial({
 		requestBodySize: Typesafe.string,
+		suppressAccessLog: (val: unknown) => {
+			if (!val) {
+				return undefined
+			}
+			if (val === 'true' || val === '1' || val === 'on') {
+				return true
+			}
+			if (val === 'false' || val === '0' || val === 'off') {
+				return false
+			}
+			if (typeof val === 'string') {
+				return val
+			}
+			Typesafe.fail([])
+		},
 	}),
 	contentApi: Typesafe.partial({
 		schemaCacheTtlSeconds: Typesafe.integer,

--- a/packages/engine-http/src/config/configTemplate.ts
+++ b/packages/engine-http/src/config/configTemplate.ts
@@ -81,6 +81,7 @@ export const configTemplate: any = {
 		applicationWorker: '%?env.CONTEMBER_APPLICATION_WORKER::string%',
 		http: {
 			requestBodySize: '%?env.CONTEMBER_HTTP_REQUEST_BODY_SIZE::string%',
+			suppressAccessLog: '%?env.CONTEMBER_HTTP_SUPPRESS_ACCESS_LOG::string%',
 		},
 		contentApi: {
 			schemaCacheTtlSeconds: '%?env.CONTEMBER_CONTENT_API_SCHEMA_CACHE_TTL_SECONDS::number%',

--- a/packages/logger/src/impl.ts
+++ b/packages/logger/src/impl.ts
@@ -6,7 +6,7 @@ import {
 	LoggerChildOptions,
 	LoggerHandler,
 	LoggerOptions,
-	LogLevel,
+	LogLevel, LogLevelName,
 } from './types'
 import { LogLevels } from './levels'
 import { formatLogEntryAttributes, formatLoggerAttributes, FormattedAttributes, stringify } from './formatting'
@@ -49,23 +49,28 @@ export class LoggerImpl implements Logger {
 	}
 
 	public crit(messageOrError: unknown, attributes?: LoggerAttributes) {
-		this.minLevelValue <= LogLevels.crit.value && this.log(LogLevels.crit, messageOrError, attributes)
+		this.minLevelValue <= LogLevels.crit.value && this.doLog(LogLevels.crit, messageOrError, attributes)
 	}
 
 	public error(messageOrError: unknown, attributes?: LoggerAttributes) {
-		this.minLevelValue <= LogLevels.error.value && this.log(LogLevels.error, messageOrError, attributes)
+		this.minLevelValue <= LogLevels.error.value && this.doLog(LogLevels.error, messageOrError, attributes)
 	}
 
 	public warn(messageOrError: unknown, attributes?: LoggerAttributes) {
-		this.minLevelValue <= LogLevels.warn.value && this.log(LogLevels.warn, messageOrError, attributes)
+		this.minLevelValue <= LogLevels.warn.value && this.doLog(LogLevels.warn, messageOrError, attributes)
 	}
 
 	public info(messageOrError: unknown, attributes?: LoggerAttributes) {
-		this.minLevelValue <= LogLevels.info.value && this.log(LogLevels.info, messageOrError, attributes)
+		this.minLevelValue <= LogLevels.info.value && this.doLog(LogLevels.info, messageOrError, attributes)
 	}
 
 	public debug(messageOrError: unknown, attributes?: LoggerAttributes) {
-		this.minLevelValue <= LogLevels.debug.value && this.log(LogLevels.debug, messageOrError, attributes)
+		this.minLevelValue <= LogLevels.debug.value && this.doLog(LogLevels.debug, messageOrError, attributes)
+	}
+
+	public log(levelName: LogLevelName, messageOrError: unknown, attributes?: LoggerAttributes) {
+		const level = LogLevels[levelName]
+		this.minLevelValue <= level.value && this.doLog(level, messageOrError, attributes)
 	}
 
 	public child(attributes: LoggerAttributes = {}, options: Partial<LoggerChildOptions> = {}): Logger {
@@ -82,7 +87,7 @@ export class LoggerImpl implements Logger {
 		}
 	}
 
-	private log(level: LogLevel, errorOrMessage: unknown, { error: errorAttr, message: messageAttr, ...attributes }: LoggerAttributes = {}) {
+	private doLog(level: LogLevel, errorOrMessage: unknown, { error: errorAttr, message: messageAttr, ...attributes }: LoggerAttributes = {}) {
 		const error: unknown | undefined = typeof errorOrMessage !== 'string' ? errorOrMessage : errorAttr
 		const errorMessage = typeof error === 'object' && error !== null && typeof (error as any).message === 'string'
 			? (error as any).message : undefined

--- a/packages/logger/src/proxy.ts
+++ b/packages/logger/src/proxy.ts
@@ -24,6 +24,10 @@ class CurrentLoggerProxy implements Logger {
 		getLogger().debug(a, b)
 	}
 
+	log(level: any, a: any, b?: any, c?: any) {
+		getLogger().log(level, a, b)
+	}
+
 	child(attributes?: LoggerAttributes, options?: Partial<LoggerOptions>): Logger {
 		return getLogger().child(attributes, options)
 	}

--- a/packages/logger/src/types.ts
+++ b/packages/logger/src/types.ts
@@ -11,6 +11,8 @@ export interface Logger {
 	info: LogFn
 	debug: LogFn
 
+	log(level: LogLevelName, messageOrError: unknown, attributes?: LoggerAttributes): void
+
 	child(attributes?: LoggerAttributes, options?: Partial<LoggerChildOptions>): Logger
 	scope<T>(cb: (logger: Logger) => Promise<T> | T, attributes?: LoggerAttributes, options?: Partial<LoggerChildOptions>): Promise<T>
 	close(): void


### PR DESCRIPTION
this PR adds following features:
- add `/health` endpoint on the primary http server, which returns 200 with `OK` body when the http is responding. this http endpoint does not require any authentication header or project group config
- add `CONTEMBER_HTTP_SUPPRESS_ACCESS_LOG` env option, which allows to lower the level of access logs from info to debug, either for all logs by setting this env to `1` or `true`, or by passing regex to suppress only some URLs