### PR TITLE
feat(tenant-api): add query personById

### DIFF
--- a/packages/engine-tenant-api/src/TenantContainer.ts
+++ b/packages/engine-tenant-api/src/TenantContainer.ts
@@ -55,6 +55,7 @@ import {
 	MailTemplateMutationResolver,
 	MeQueryResolver,
 	OtpMutationResolver,
+	PersonQueryResolver,
 	ProjectMembersQueryResolver,
 	ProjectQueryResolver,
 	ProjectTypeResolver,
@@ -208,6 +209,8 @@ export class TenantContainerFactory {
 				new SignInResponseFactory(permissionContextFactory, identityTypeResolver))
 			.addService('meQueryResolver', () =>
 				new MeQueryResolver())
+			.addService('personQueryResolver', ({ personManager }) =>
+				new PersonQueryResolver(personManager))
 			.addService('idpQueryResolver', ({ idpManager }) =>
 				new IDPQueryResolver(idpManager))
 			.addService('projectQueryResolver', ({ projectManager }) =>

--- a/packages/engine-tenant-api/src/model/authorization/PermissionActions.ts
+++ b/packages/engine-tenant-api/src/model/authorization/PermissionActions.ts
@@ -19,6 +19,7 @@ namespace PermissionActions {
 
 	export const PERSON_DISABLE = (roles?: readonly string[]) => Authorizator.createAction(Resources.person, 'disable', { roles })
 
+	export const PERSON_VIEW = Authorizator.createAction(Resources.person, 'view')
 	export const PERSON_SIGN_IN = Authorizator.createAction(Resources.person, 'signIn')
 	export const PERSON_SIGN_UP = (roles?: readonly string[]) => Authorizator.createAction(Resources.person, 'signUp', { roles })
 	export const PERSON_SIGN_OUT = Authorizator.createAction(Resources.person, 'signOut')

--- a/packages/engine-tenant-api/src/model/authorization/PermissionsFactory.ts
+++ b/packages/engine-tenant-api/src/model/authorization/PermissionsFactory.ts
@@ -25,6 +25,7 @@ class PermissionsFactory {
 		permissions.allow(TenantRole.LOGIN, PermissionActions.PERSON_CREATE_IDP_URL)
 		permissions.allow(TenantRole.LOGIN, PermissionActions.PERSON_SIGN_IN_IDP)
 
+		permissions.allow(TenantRole.PERSON, PermissionActions.PERSON_VIEW)
 		permissions.allow(TenantRole.PERSON, PermissionActions.PERSON_CHANGE_MY_PASSWORD)
 		permissions.allow(TenantRole.PERSON, PermissionActions.PERSON_CHANGE_MY_PROFILE)
 		permissions.allow(TenantRole.PERSON, PermissionActions.PERSON_SIGN_OUT)

--- a/packages/engine-tenant-api/src/resolvers/ResolverFactory.ts
+++ b/packages/engine-tenant-api/src/resolvers/ResolverFactory.ts
@@ -20,7 +20,7 @@ import {
 } from './mutation'
 
 import { Resolvers } from '../schema'
-import { MeQueryResolver, ProjectMembersQueryResolver, ProjectQueryResolver } from './query'
+import { MeQueryResolver, PersonQueryResolver, ProjectMembersQueryResolver, ProjectQueryResolver } from './query'
 import { IdentityTypeResolver, ProjectTypeResolver } from './types'
 import { DateTimeType, JSONType } from '@contember/graphql-utils'
 import { IDPQueryResolver } from './query/IDPQueryResolver'
@@ -32,6 +32,7 @@ class ResolverFactory {
 	public constructor(
 		private readonly resolvers: {
 			meQueryResolver: MeQueryResolver
+			personQueryResolver: PersonQueryResolver
 			projectQueryResolver: ProjectQueryResolver
 			projectMembersQueryResolver: ProjectMembersQueryResolver
 			idpQueryResolver: IDPQueryResolver
@@ -90,6 +91,7 @@ class ResolverFactory {
 			},
 			Query: {
 				me: this.resolvers.meQueryResolver.me.bind(this.resolvers.meQueryResolver),
+				personById: this.resolvers.personQueryResolver.personById.bind(this.resolvers.personQueryResolver),
 				projectBySlug: this.resolvers.projectQueryResolver.projectBySlug.bind(this.resolvers.projectQueryResolver),
 				projects: this.resolvers.projectQueryResolver.projects.bind(this.resolvers.projectQueryResolver),
 				projectMemberships: this.resolvers.projectMembersQueryResolver.projectMemberships.bind(this.resolvers.projectMembersQueryResolver),

--- a/packages/engine-tenant-api/src/resolvers/query/PersonQueryResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/query/PersonQueryResolver.ts
@@ -1,0 +1,26 @@
+import {
+	Maybe,
+	Person,
+	QueryPersonByIdArgs,
+	QueryResolvers,
+} from '../../schema'
+import { TenantResolverContext } from '../TenantResolverContext'
+import { PermissionActions, PersonManager } from '../../model'
+import { PersonResponseFactory } from '../responseHelpers/PersonResponseFactory'
+
+export class PersonQueryResolver implements QueryResolvers {
+	constructor(private readonly personManager: PersonManager) {}
+
+	async personById(
+		parent: unknown,
+		args: QueryPersonByIdArgs,
+		context: TenantResolverContext,
+	): Promise<Maybe<Person>> {
+		const person = await this.personManager.findPersonById(context.db, args.id)
+		if (!person || !(await context.isAllowed({ action: PermissionActions.PERSON_VIEW }))) {
+			return null
+		}
+
+		return await PersonResponseFactory.createPersonResponse(person)
+	}
+}

--- a/packages/engine-tenant-api/src/resolvers/query/index.ts
+++ b/packages/engine-tenant-api/src/resolvers/query/index.ts
@@ -1,3 +1,4 @@
 export * from './MeQueryResolver'
 export * from './ProjectMembersQueryResolver'
 export * from './ProjectQueryResolver'
+export * from './PersonQueryResolver'

--- a/packages/engine-tenant-api/src/schema/index.ts
+++ b/packages/engine-tenant-api/src/schema/index.ts
@@ -905,6 +905,7 @@ export type Query = {
 	readonly checkResetPasswordToken: CheckResetPasswordTokenCode
 	readonly identityProviders: ReadonlyArray<IdentityProvider>
 	readonly me: Identity
+	readonly personById?: Maybe<Person>
 	readonly projectBySlug?: Maybe<Project>
 	readonly projectMemberships: ReadonlyArray<Membership>
 	readonly projects: ReadonlyArray<Project>
@@ -914,6 +915,11 @@ export type Query = {
 export type QueryCheckResetPasswordTokenArgs = {
 	requestId: Scalars['String']['input']
 	token: Scalars['String']['input']
+}
+
+
+export type QueryPersonByIdArgs = {
+	id: Scalars['String']['input']
 }
 
 
@@ -2032,6 +2038,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
 	checkResetPasswordToken?: Resolver<ResolversTypes['CheckResetPasswordTokenCode'], ParentType, ContextType, RequireFields<QueryCheckResetPasswordTokenArgs, 'requestId' | 'token'>>
 	identityProviders?: Resolver<ReadonlyArray<ResolversTypes['IdentityProvider']>, ParentType, ContextType>
 	me?: Resolver<ResolversTypes['Identity'], ParentType, ContextType>
+	personById?: Resolver<Maybe<ResolversTypes['Person']>, ParentType, ContextType, RequireFields<QueryPersonByIdArgs, 'id'>>
 	projectBySlug?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType, RequireFields<QueryProjectBySlugArgs, 'slug'>>
 	projectMemberships?: Resolver<ReadonlyArray<ResolversTypes['Membership']>, ParentType, ContextType, RequireFields<QueryProjectMembershipsArgs, 'identityId' | 'projectSlug'>>
 	projects?: Resolver<ReadonlyArray<ResolversTypes['Project']>, ParentType, ContextType>

--- a/packages/engine-tenant-api/src/schema/tenant.graphql.ts
+++ b/packages/engine-tenant-api/src/schema/tenant.graphql.ts
@@ -12,6 +12,7 @@ const schema: DocumentNode = gql`
 
 	type Query {
 		me: Identity!
+		personById(id: String!): Person
 		projects: [Project!]!
 		projectBySlug(slug: String!): Project
 		projectMemberships(projectSlug: String!, identityId: String!): [Membership!]!

--- a/packages/engine-tenant-api/tests/cases/integration/mocked/personByIdQuery.test.ts
+++ b/packages/engine-tenant-api/tests/cases/integration/mocked/personByIdQuery.test.ts
@@ -1,0 +1,47 @@
+import { executeTenantTest } from '../../../src/testTenant'
+import { GQL } from '../../../src/tags'
+import { testUuid } from '../../../src/testUuid'
+import { test } from 'vitest'
+import { getPersonByIdSql } from './sql/getPersonByIdSql'
+
+test('get person by id query', async () => {
+	const name = 'John Doe'
+	const email = 'john@doe.com'
+	const personId = testUuid(1)
+	const identityId = testUuid(2)
+
+	await executeTenantTest({
+		query: {
+			query: GQL`
+query personById($id: String!) {
+	personById(id: $id) {
+		id
+		name
+		email
+		identity {
+			id
+		}
+	}
+}`,
+			variables: { id: personId },
+		},
+		executes: [
+			getPersonByIdSql({
+				personId,
+				response: { personId, email, roles: [], password: '123', identityId, name },
+			}),
+		],
+		return: {
+			data: {
+				personById: {
+					id: personId,
+					name,
+					email,
+					identity: {
+						id: identityId,
+					},
+				},
+			},
+		},
+	})
+})

--- a/packages/engine-tenant-api/tests/cases/integration/mocked/sql/getPersonByIdSql.ts
+++ b/packages/engine-tenant-api/tests/cases/integration/mocked/sql/getPersonByIdSql.ts
@@ -3,7 +3,7 @@ import { SQL } from '../../../../src/tags'
 
 export const getPersonByIdSql = (args: {
 	personId: string
-	response: { personId: string; password: string; identityId: string; roles: string[]; email: string }
+	response: { personId: string; password: string; identityId: string; roles: string[]; email: string; name?: string }
 }): ExpectedQuery => ({
 	sql: SQL`SELECT "person"."id", "person"."password_hash", "person"."otp_uri", "person"."otp_activated_at", "person"."identity_id", "person"."email", "person"."name", "person"."disabled_at", "identity"."roles"
 	         FROM "tenant"."person"
@@ -17,7 +17,8 @@ export const getPersonByIdSql = (args: {
 				password_hash: `BCRYPTED-${args.response.password}`,
 				identity_id: args.response.identityId,
 				roles: args.response.roles,
-				mail: args.response.email,
+				email: args.response.email,
+				name: args.response.name,
 			},
 		],
 	},


### PR DESCRIPTION
Implements this query on Tenant API

```graphql
query personById($id: String!) {
	personById(id: $id) {
		id
		name
		email
		identity {
			id
		}
	}
}
```