### PR TITLE
chore: add postgres 16 to test matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        postgres: [11, 12, 13, 14, 15]
+        postgres: [11, 12, 13, 14, 15, 16]
     services:
       postgres:
         image: postgres:${{ matrix.postgres }}


### PR DESCRIPTION
AWS adds support for Aurora Postgres 16.1 so it will be great to test against PG 16.x