### PR TITLE
`yawn-yaml` version that support both CommonJS and ESM without explicit import

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,6 @@
     "preact-render-to-string": "^6.3.1",
     "prompts": "^2.4.2",
     "semver": "^7.5.4",
-    "yawn-yaml": "^1.5.0"
+    "yawn-yaml": "^2.2.0"
   }
 }

--- a/packages/cli/src/utils/yaml.ts
+++ b/packages/cli/src/utils/yaml.ts
@@ -1,5 +1,5 @@
 import { JSONObject, JSONPrimitive, pathExists } from '@contember/cli-common'
-import YAWN from 'yawn-yaml/cjs'
+import YAWN from 'yawn-yaml'
 import { Merger } from '@contember/config-loader'
 import jsyaml from 'js-yaml'
 import { readFile, writeFile } from 'node:fs/promises'

--- a/packages/cli/types/yawn-yaml/index.d.ts
+++ b/packages/cli/types/yawn-yaml/index.d.ts
@@ -1,7 +1,0 @@
-declare module 'yawn-yaml/cjs' {
-	export default class YAWN {
-		json: any
-		readonly yaml: string
-		constructor(yaml: string)
-	}
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -780,7 +780,7 @@ __metadata:
     prompts: ^2.4.2
     semver: ^7.5.4
     tailwindcss: ^3.3.5
-    yawn-yaml: ^1.5.0
+    yawn-yaml: ^2.2.0
   bin:
     contember: ./dist/src/run.js
   languageName: unknown
@@ -3057,15 +3057,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"argparse@npm:^1.0.7":
-  version: 1.0.10
-  resolution: "argparse@npm:1.0.10"
-  dependencies:
-    sprintf-js: ~1.0.2
-  checksum: 7ca6e45583a28de7258e39e13d81e925cfa25d7d4aacbf806a382d3c02fcb13403a07fb8aeef949f10a7cfe4a62da0e2e807b348a5980554cc28ee573ef95945
-  languageName: node
-  linkType: hard
-
 "argparse@npm:^2.0.1":
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
@@ -4503,16 +4494,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esprima@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "esprima@npm:4.0.1"
-  bin:
-    esparse: ./bin/esparse.js
-    esvalidate: ./bin/esvalidate.js
-  checksum: b45bc805a613dbea2835278c306b91aff6173c8d034223fa81498c77dcbce3b2931bf6006db816f62eacd9fd4ea975dfd85a5b7f3c6402cfd050d4ca3c13a628
-  languageName: node
-  linkType: hard
-
 "esquery@npm:^1.4.2":
   version: 1.5.0
   resolution: "esquery@npm:1.5.0"
@@ -5834,18 +5815,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.4.2":
-  version: 3.14.1
-  resolution: "js-yaml@npm:3.14.1"
-  dependencies:
-    argparse: ^1.0.7
-    esprima: ^4.0.0
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: bef146085f472d44dee30ec34e5cf36bf89164f5d585435a3d3da89e52622dff0b188a580e4ad091c3341889e14cb88cac6e4deb16dc5b1e9623bb0601fc255c
-  languageName: node
-  linkType: hard
-
 "js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0":
   version: 4.1.0
   resolution: "js-yaml@npm:4.1.0"
@@ -6143,7 +6112,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.11, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:~4.17.0":
+"lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:~4.17.0":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
@@ -8237,13 +8206,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sprintf-js@npm:~1.0.2":
-  version: 1.0.3
-  resolution: "sprintf-js@npm:1.0.3"
-  checksum: 19d79aec211f09b99ec3099b5b2ae2f6e9cdefe50bc91ac4c69144b6d3928a640bb6ae5b3def70c2e85a2c3d9f5ec2719921e3a59d3ca3ef4b2fd1a4656a0df3
-  languageName: node
-  linkType: hard
-
 "ssri@npm:^9.0.0":
   version: 9.0.1
   resolution: "ssri@npm:9.0.1"
@@ -9332,10 +9294,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml-js@npm:^0.1.3":
-  version: 0.1.5
-  resolution: "yaml-js@npm:0.1.5"
-  checksum: c7c08a660baefd8acf9aa526077b9f6e0823868e40e60ea3657e7fdb77c321b53b5587ac95f091a95df7996ccd6fa29269ba7b500a340ae9eee6404aacc6f82a
+"yaml-js@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "yaml-js@npm:0.3.1"
+  checksum: b90dc9391c1a2337de77a2309712cacd8bf9b162a0688df03a1928e612a812ba3ea7d3a44af3e00b9bf2e8e682dc8e7503018c665126d5c4794dc69a3eb8f843
   languageName: node
   linkType: hard
 
@@ -9419,14 +9381,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yawn-yaml@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "yawn-yaml@npm:1.5.0"
+"yawn-yaml@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "yawn-yaml@npm:2.2.0"
   dependencies:
-    js-yaml: ^3.4.2
-    lodash: ^4.17.11
-    yaml-js: ^0.1.3
-  checksum: cf7d07006cebca05687dca57a76236b3ebd605c395cb2001719b782f10fc5685b2ac547b26fbf4f7884f18a977aaedbaaa8da831309c88f653581437a8177a37
+    js-yaml: ^4.1.0
+    lodash: ^4.17.21
+    yaml-js: ^0.3.1
+  checksum: 8c59b0ff8b5c573258850cd73fddf97d2956b37aa83fdb680f3c6abda573cf3d53157b54470dc4759acd83b4c195c68a1981df7999077ccf6006dc8a02d9c74a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Version `1.5.0` requires explicit import for CommonJS via `yawn-yaml/cjs`, version `1.5.1` brings support for just `yawn-yaml` for both CommonJS and ESM.

Project was rewritten to TypeScript and should be 1:1 but if we want to be sure and dont need any concerns we can upgrade just to `1.5.1`