### PR TITLE
migrations: allow to set column value with "using" 

### DIFF
--- a/packages/schema-migrations/tests/cases/integration/createColumn.test.ts
+++ b/packages/schema-migrations/tests/cases/integration/createColumn.test.ts
@@ -11,10 +11,11 @@ testMigrations('create a column with default value', {
 	}),
 	updated: createSchema({
 		Author: class Author {
-			name = def.stringColumn().default('unnamed author').notNull()
+			name = def.stringColumn().notNull()
 			email = def.stringColumn().unique()
 		},
 	}),
+	noDiff: true,
 	diff: [
 		{
 			modification: 'createColumn',
@@ -23,7 +24,6 @@ testMigrations('create a column with default value', {
 				columnName: 'name',
 				name: 'name',
 				nullable: false,
-				default: 'unnamed author',
 				type: Model.ColumnType.String,
 				columnType: 'text',
 			},
@@ -67,4 +67,37 @@ testMigrations('create a column with copy value', {
 UPDATE "author" SET "name" = "email"::text;
 SET CONSTRAINTS ALL IMMEDIATE; SET CONSTRAINTS ALL DEFERRED;
 ALTER TABLE "author" ALTER "name" SET NOT NULL;`,
+})
+
+
+testMigrations('create a column with default value with "using"', {
+	original: createSchema({
+		Author: class Author {
+			email = def.stringColumn().unique()
+		},
+	}),
+	updated: createSchema({
+		Author: class Author {
+			name = def.stringColumn().default('unnamed author').notNull()
+			email = def.stringColumn().unique()
+		},
+	}),
+	diff: [
+		{
+			modification: 'createColumn',
+			entityName: 'Author',
+			field: {
+				columnName: 'name',
+				name: 'name',
+				nullable: false,
+				default: 'unnamed author',
+				type: Model.ColumnType.String,
+				columnType: 'text',
+			},
+			fillValue: 'unnamed author',
+			valueMigrationStrategy: 'using',
+		},
+	],
+	sql: SQL`ALTER TABLE "author" ADD "name" text;
+ALTER TABLE "author" ALTER "name" SET DATA TYPE text USING $pga$unnamed author$pga$, ALTER "name" SET NOT NULL;`,
 })

--- a/packages/schema-migrations/tests/cases/integration/updateColumnDefinition.test.ts
+++ b/packages/schema-migrations/tests/cases/integration/updateColumnDefinition.test.ts
@@ -205,3 +205,23 @@ UPDATE "author" SET "name" = $pga$unnamed$pga$ WHERE "name" IS NULL;
 SET CONSTRAINTS ALL IMMEDIATE; SET CONSTRAINTS ALL DEFERRED;
 ALTER TABLE "author" ALTER "name" SET NOT NULL;`,
 })
+
+testMigrations('set not null and fill with "using"', {
+	original: createSchema(NotNullOrig),
+	updated: createSchema(NotNullUpdated),
+	noDiff: true,
+	diff: [
+		updateColumnDefinitionModification.createModification({
+			entityName: 'Author',
+			fieldName: 'name',
+			definition: {
+				type: Model.ColumnType.String,
+				columnType: 'text',
+				nullable: false,
+			},
+			fillValue: 'unnamed',
+			valueMigrationStrategy: 'using',
+		}),
+	],
+	sql: SQL` ALTER TABLE "author" ALTER "name" SET DATA TYPE text USING COALESCE("name"::text, $pga$unnamed$pga$), ALTER "name" SET NOT NULL;`,
+})


### PR DESCRIPTION
Enhance performance and flexibility by introducing the `valueMigrationStrategy` option in `createColumn` and `updateColumnDefinition` migrations. This option allows you to specify whether to employ a DML `update` statement or a DDL `using` statement when setting values with the `fillValue` or `copyValue` parameters.

Using the `using` strategy provides improved performance benefits during column addition or modification.  This efficiency gain is largely due to the strategy not recording changes in the event audit log.

When a migration involving `fillValue` is generated via a diff—triggered by setting a default value on a column—the system now automatically opts for the `using` strategy for optimal efficiency.