### PR TITLE
migration tables: do not use sequences

### DIFF
--- a/packages/engine-system-api/src/migrations/2024-06-28-150000-migrations-drop-sequence.ts
+++ b/packages/engine-system-api/src/migrations/2024-06-28-150000-migrations-drop-sequence.ts
@@ -1,0 +1,15 @@
+import { MigrationBuilder } from '@contember/database-migrations'
+
+const sql = `
+ALTER TABLE schema_migration ALTER id DROP DEFAULT;
+DO LANGUAGE plpgsql
+$$
+	BEGIN
+		EXECUTE FORMAT('DROP SEQUENCE %s', PG_GET_SERIAL_SEQUENCE('schema_migration', 'id'));
+	END
+$$
+`
+
+export default async function (builder: MigrationBuilder) {
+	builder.sql(sql)
+}

--- a/packages/engine-system-api/src/migrations/runner.ts
+++ b/packages/engine-system-api/src/migrations/runner.ts
@@ -25,6 +25,7 @@ import _20221003110000tableondelete from './2022-10-03-110000-table-on-delete'
 import _20230911174000fixondelete from './2023-09-11-174000-fix-on-delete'
 import _20231019173000fixunique from './2023-10-19-173000-fix-unique'
 import _20231024140000schemanullablechecksum from './2023-10-24-140000-schema-nullable-checksum'
+import _20240628150000migrationsdropsequence from './2024-06-28-150000-migrations-drop-sequence'
 import snapshot from './snapshot'
 
 import { Connection, createDatabaseIfNotExists, DatabaseConfig, DatabaseMetadataResolver } from '@contember/database'
@@ -54,6 +55,7 @@ const migrations = {
 	'2023-09-11-174000-fix-on-delete': _20230911174000fixondelete,
 	'2023-10-19-173000-fix-unique': _20231019173000fixunique,
 	'2023-10-24-140000-schema-nullable-checksum': _20231024140000schemanullablechecksum,
+	'2024-06-28-150000-migrations-drop-sequence': _20240628150000migrationsdropsequence,
 }
 
 

--- a/packages/engine-system-api/src/migrations/snapshot.ts
+++ b/packages/engine-system-api/src/migrations/snapshot.ts
@@ -124,14 +124,6 @@ CREATE TABLE "schema_migration" (
     "executed_at" timestamp with time zone DEFAULT "now"() NOT NULL,
     "type" "schema_migration_type" DEFAULT 'schema'::"schema_migration_type" NOT NULL
 );
-CREATE SEQUENCE "schema_migration_id_seq"
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-ALTER SEQUENCE "schema_migration_id_seq" OWNED BY "schema_migration"."id";
 CREATE TABLE "stage" (
     "id" "uuid" NOT NULL,
     "name" "text" NOT NULL,
@@ -143,7 +135,6 @@ CREATE TABLE "stage_transaction" (
     "stage_id" "uuid" NOT NULL,
     "applied_at" timestamp with time zone NOT NULL
 );
-ALTER TABLE ONLY "schema_migration" ALTER COLUMN "id" SET DEFAULT "nextval"('"schema_migration_id_seq"'::"regclass");
 ALTER TABLE ONLY "event_data"
     ADD CONSTRAINT "event_data_pkey" PRIMARY KEY ("id");
 ALTER TABLE ONLY "schema_migration"


### PR DESCRIPTION
Sequences have some performance impacts, e.g. longer downtime during blue-green aws deployment.